### PR TITLE
fix: build with 16kb page size support

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -113,7 +113,11 @@ jobs:
 
       - name: Generate
         working-directory: ./package
-        run: bare-make generate --platform ${{ inputs.platform }} --arch ${{ inputs.arch }}
+        run: |
+          bare-make generate \
+            --platform ${{ inputs.platform }} \
+            --arch ${{ inputs.arch }} \
+            -D CMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384"
 
       - name: Build
         working-directory: ./package


### PR DESCRIPTION
This adds linker flags to the `bare-make generate` step in accordance with the [Android guidelines](https://developer.android.com/guide/practices/page-sizes#build) in order to support 16KB page sizes.

The modules that we maintain that use this workflow for builds currently run this workflow from the `main` branch, so after merging this, it should just be a case of re-running the prebuild workflow for each dependency.

I have tested this by [creating a temporary branch](https://github.com/digidem/simdle-native-nodejs-mobile/tree/fix/16kb-page-size) for our simdle-native build repo and running the workflow in this PR, then checking that the built files (a) still work in the mobile app and (b) the resulting APK no longer gives a warning about simdle-native when checking for 16KB page sizes.