### PR TITLE
feat: switch to a re-usable action

### DIFF
--- a/.github/actions/prebuild/action.yml
+++ b/.github/actions/prebuild/action.yml
@@ -1,0 +1,121 @@
+name: "Generate prebuild"
+description: "Build a nodejs-mobile prebuild for a native module"
+
+inputs:
+  module_name:
+    description: "The name of the module to prebuild"
+    required: true
+  platform:
+    description: "The platform to prebuild for"
+    required: true
+    default: "android"
+  arch:
+    description: "The architecture to prebuild for"
+    required: true
+    default: "arm64"
+  module_version:
+    description: "The version of the module to prebuild"
+    required: false
+    default: "latest"
+  patch_file:
+    description:
+      "Path to patch file to apply to the module (resolved relative to the
+      caller's workspace)"
+    required: false
+  node_version:
+    description: "Node.js version to use"
+    required: false
+    default: "24"
+
+outputs:
+  module_version:
+    description: "The resolved version of the module"
+    value: ${{ steps.parse-module-version.outputs.version }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Validate runner for platform
+      shell: bash
+      run: |
+        case "${{ inputs.platform }}" in
+          ios|macos)
+            if [ "$RUNNER_OS" != "macOS" ]; then
+              echo "::error::Platform '${{ inputs.platform }}' requires a macOS runner, but runner is '$RUNNER_OS'. Set 'runs-on: macos-latest' (or similar) in the calling job."
+              exit 1
+            fi
+            ;;
+        esac
+
+    - name: Use Node.js ${{ inputs.node_version }}
+      uses: actions/setup-node@v6
+      with:
+        node-version: ${{ inputs.node_version }}
+
+    - name: Download npm package and unpack
+      shell: bash
+      run:
+        npm pack ${{ inputs.module_name }}@${{ inputs.module_version }} | xargs
+        tar -zxvf
+
+    - name: Apply patch if provided
+      if: ${{ inputs.patch_file }}
+      shell: bash
+      run: |
+        if [ -f "${{ inputs.patch_file }}" ]; then
+          echo "Applying patch: ${{ inputs.patch_file }}"
+          cd package
+          patch -p1 < ../${{ inputs.patch_file }}
+        else
+          echo "Patch file not found: ${{ inputs.patch_file }}"
+          exit 1
+        fi
+
+    - name: Parse module version
+      id: parse-module-version
+      shell: bash
+      working-directory: ./package
+      run: echo version=$(jq -r .version package.json) >> $GITHUB_OUTPUT
+
+    - name: Install bare-make
+      shell: bash
+      run: npm install -g bare-make
+
+    - name: Install deps for package
+      shell: bash
+      working-directory: ./package
+      run: npm install
+
+    - name: Install patched cmake-napi
+      shell: bash
+      working-directory: ./package
+      run: npm install cmake-napi@github:digidem/cmake-napi-nodejs-mobile
+
+    - name: Generate
+      shell: bash
+      working-directory: ./package
+      run: |
+        bare-make generate \
+          --platform ${{ inputs.platform }} \
+          --arch ${{ inputs.arch }} \
+          -D CMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384"
+
+    - name: Build
+      shell: bash
+      working-directory: ./package
+      run: bare-make build
+
+    - name: Install
+      shell: bash
+      working-directory: ./package
+      run: bare-make install
+
+    - name: Upload prebuild artifacts
+      uses: actions/upload-artifact@v7
+      with:
+        name:
+          ${{ inputs.module_name }}-${{
+          steps.parse-module-version.outputs.version }}-${{ inputs.platform
+          }}-${{ inputs.arch }}
+        path:
+          ./package/prebuilds/${{ inputs.platform }}-${{ inputs.arch }}/*.node

--- a/.github/actions/prebuild/action.yml
+++ b/.github/actions/prebuild/action.yml
@@ -95,10 +95,16 @@ runs:
       shell: bash
       working-directory: ./package
       run: |
+        extra_args=()
+        case "${{ inputs.platform }}" in
+          android|linux)
+            extra_args+=(-D CMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384")
+            ;;
+        esac
         bare-make generate \
           --platform ${{ inputs.platform }} \
           --arch ${{ inputs.arch }} \
-          -D CMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384"
+          "${extra_args[@]}"
 
     - name: Build
       shell: bash

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -13,6 +13,7 @@ on:
         required: true
         options:
           - "android"
+          - "ios"
         default: "android"
       arch:
         type: choice

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -32,6 +32,15 @@ on:
         type: string
         description: "Path to patch file to apply to the module (optional)"
         required: false
+      runner:
+        type: choice
+        description: "The runner to use for the build"
+        required: true
+        options:
+          - "ubuntu-22.04"
+          - "macos-latest"
+          - "windows-latest"
+        default: "ubuntu-22.04"
   workflow_call:
     inputs:
       module_name:
@@ -57,78 +66,31 @@ on:
         type: string
         description: "Path to patch file to apply to the module (optional)"
         required: false
+      runner:
+        type: string
+        description: "The runner to use for the build"
+        required: true
+        default: "ubuntu-22.04"
     outputs:
       module_version:
         description: "The version of the module"
         value: ${{ jobs.build.outputs.module_version }}
 
-env:
-  NODE_VERSION: 18
-
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 10
     name: ${{ inputs.module_name }} (${{ inputs.platform }}-${{ inputs.arch }})
     outputs:
-      module_version: ${{ steps.parse-module-version.outputs.version }}
-
+      module_version: ${{ steps.prebuild.outputs.module_version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v4
+      - uses: ./.github/actions/prebuild
+        id: prebuild
         with:
-          node-version: ${{ env.NODE_VERSION }}
-
-      - name: Download npm package and unpack
-        run: npm pack ${{ inputs.module_name }}@${{ inputs.module_version }} | xargs tar -zxvf
-
-      - name: Apply patch if provided
-        if: ${{ inputs.patch_file }}
-        run: |
-          if [ -f "${{ inputs.patch_file }}" ]; then
-            echo "Applying patch: ${{ inputs.patch_file }}"
-            cd package
-            patch -p1 < ../${{ inputs.patch_file }}
-          else
-            echo "Patch file not found: ${{ inputs.patch_file }}"
-            exit 1
-          fi
-
-      - name: Parse module version
-        id: parse-module-version
-        working-directory: ./package
-        run: echo version=$(jq -r .version package.json) >> $GITHUB_OUTPUT
-
-      - run: npm install -g bare-make
-
-      - name: Install deps for package
-        working-directory: ./package
-        run: npm install
-
-      - name: Install patched cmake-napi
-        working-directory: ./package
-        run: npm install cmake-napi@github:digidem/cmake-napi-nodejs-mobile
-
-      - name: Generate
-        working-directory: ./package
-        run: |
-          bare-make generate \
-            --platform ${{ inputs.platform }} \
-            --arch ${{ inputs.arch }} \
-            -D CMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384"
-
-      - name: Build
-        working-directory: ./package
-        run: bare-make build
-
-      - name: Install
-        working-directory: ./package
-        run: bare-make install
-
-      - name: Upload original prebuild artifacts # mostly for debugging purposes
-        uses: actions/upload-artifact@v4
-        with:
-          name: ${{ inputs.module_name }}-${{ steps.parse-module-version.outputs.version }}-${{ inputs.platform }}-${{ inputs.arch }}
-          path: ./package/prebuilds/${{ inputs.platform }}-${{ inputs.arch }}/*.node
+          module_name: ${{ inputs.module_name }}
+          platform: ${{ inputs.platform }}
+          arch: ${{ inputs.arch }}
+          module_version: ${{ inputs.module_version }}
+          patch_file: ${{ inputs.patch_file }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: prebuilds
 
@@ -24,7 +24,7 @@ jobs:
           done
 
       - name: Create GitHub Release
-        uses: ncipollo/release-action@v1
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
         with:
           artifacts: "artifacts/*"
           artifactErrorsFailBuild: true

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # nodejs-mobile-bare-prebuilds
 
-This repository contains shared workflows for building native modules maintained by the Holepunch team. These modules are built using [`bare-make`](https://github.com/holepunchto/bare-make).
+This repository contains shared workflows for building native modules maintained
+by the Holepunch team. These modules are built using
+[`bare-make`](https://github.com/holepunchto/bare-make).
 
 ## Table of Contents
 
@@ -12,29 +14,92 @@ This repository contains shared workflows for building native modules maintained
 
 ## Introduction
 
-The `nodejs-mobile-bare-prebuilds` repository provides a set of workflows and tools to streamline the process of building native modules for Node.js mobile applications. These workflows are designed to be used with the `bare-make` build system.
+The `nodejs-mobile-bare-prebuilds` repository provides a set of workflows and
+tools to streamline the process of building native modules for Node.js mobile
+applications. These workflows are designed to be used with the `bare-make` build
+system.
 
 ## Usage
 
-To use the workflows in this repository, you need to reference them in your workflow job as follows:
+The prebuild step is published as a composite action. Call it from a job in your
+own repository, typically inside a matrix so each architecture builds in
+parallel. The `release.yml` reusable workflow collects the uploaded artifacts
+and creates a GitHub Release.
 
 ```yaml
+name: Generate prebuilds
+
+on:
+  workflow_dispatch:
+    inputs:
+      module_version:
+        description: "Module version"
+        required: true
+        default: "latest"
+        type: string
+      publish_release:
+        description: "Publish release"
+        required: false
+        default: true
+        type: boolean
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        platform: [android]
+        arch: [arm64, x64, arm]
+    runs-on: ubuntu-22.04
+    outputs:
+      module_version: ${{ steps.prebuild.outputs.module_version }}
     steps:
-      - uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/prebuild.yml
+      - uses: actions/checkout@v6
+      - id: prebuild
+        uses: digidem/nodejs-mobile-bare-prebuilds/.github/actions/prebuild@main
         with:
-          module_name: <module-name>
-          module_version: <module-version>
-          platform: android
-          arch: arm64 | arm | x64
+          module_name: quickbit-native
+          module_version: ${{ inputs.module_version }}
+          platform: ${{ matrix.platform }}
+          arch: ${{ matrix.arch }}
+          patch_file: CMakeLists.txt.patch
+
+  release:
+    if: ${{ inputs.publish_release }}
+    needs: build
+    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/release.yml@main
+    with:
+      module_version: ${{ needs.build.outputs.module_version }}
 ```
+
+### Inputs
+
+| Input            | Required | Default   | Description                                                          |
+| ---------------- | -------- | --------- | -------------------------------------------------------------------- |
+| `module_name`    | yes      | —         | Name of the npm module to prebuild                                   |
+| `platform`       | yes      | `android` | Target platform                                                      |
+| `arch`           | yes      | `arm64`   | Target architecture (`arm64`, `x64`, `arm`)                          |
+| `module_version` | no       | `latest`  | Version of the module to pull from npm                               |
+| `patch_file`     | no       | —         | Path to a patch file in the caller's workspace to apply to `package` |
+| `node_version`   | no       | `18`      | Node.js version used to run `bare-make`                              |
+
+### Outputs
+
+| Output           | Description                                   |
+| ---------------- | --------------------------------------------- |
+| `module_version` | The resolved version read from `package.json` |
+
+### Manual dispatch
+
+The `.github/workflows/prebuild.yml` workflow in this repository is kept as a
+thin wrapper around the composite action so the build can be triggered manually
+from the Actions tab for debugging.
 
 ## Contributing
 
-We welcome contributions to this repository. If you have an idea for a new feature or have found a bug, please open an issue or submit a pull request.
+We welcome contributions to this repository. If you have an idea for a new
+feature or have found a bug, please open an issue or submit a pull request.
 
 ## License
 
-This project is licensed under the MIT License. See the [LICENSE](LICENSE) file for more details.
+This project is licensed under the MIT License. See the [LICENSE](LICENSE) file
+for more details.


### PR DESCRIPTION
This switches the re-usable workflow to a composite re-usable action. This gives the caller control over the runner, and avoids a separate runner being used for the prebuild. It also makes the checkout semantics less confusing - previously the re-usable workflow also needed to checkout the code. It allows more flexibility also with the caller being able to include additional steps.

This _should_ be backwards-compatible, via the prebuild.yml workflow which wraps the composite action.