### PR TITLE
feat: add reusable workflows to run prebuilds on emulator/simulator

### DIFF
--- a/.github/actions/assemble-test-project/action.yml
+++ b/.github/actions/assemble-test-project/action.yml
@@ -1,0 +1,96 @@
+name: "Assemble nodejs-project for testing"
+description: |
+  Downloads a prebuild artifact, installs the module under test into a
+  `nodejs-project/` tree, drops the prebuilt `.node` files into
+  `node_modules/<module>/prebuilds/<target>/`, and places a `main.js` entry
+  point (either the caller's test script, or a generated require() smoke test
+  from default-smoke-test.js).
+
+  Requires `node`/`npm` on PATH — add an `actions/setup-node` step before
+  calling this action.
+
+inputs:
+  module_name:
+    description: "npm module being tested (e.g. 'sodium-native')"
+    required: true
+  module_version:
+    description: "Version of the module to install"
+    required: true
+  artifact_name:
+    description: "Name of the prebuild artifact uploaded earlier in the run"
+    required: true
+  target:
+    description: |
+      The `prebuilds/<dir>/` subfolder to install the .node file into.
+      This is what the runtime loader (require-addon / bare-addon-resolve)
+      will look for at `process.platform + '-' + process.arch`.
+    required: true
+  test_script:
+    description: |
+      Path to the test script (relative to $GITHUB_WORKSPACE). If empty, a
+      default smoke test is generated from default-smoke-test.js.
+    required: false
+    default: ""
+  nodejs_project_dir:
+    description:
+      "Absolute or workspace-relative directory to assemble the nodejs-project
+      tree in. Created if it does not exist."
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Download prebuild artifact
+      uses: actions/download-artifact@v4
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: ${{ runner.temp }}/prebuild
+
+    - name: Install module and place prebuild
+      shell: bash
+      env:
+        MODULE_NAME: ${{ inputs.module_name }}
+        MODULE_VERSION: ${{ inputs.module_version }}
+        TARGET: ${{ inputs.target }}
+        NODEDIR: ${{ inputs.nodejs_project_dir }}
+      run: |
+        set -euo pipefail
+        mkdir -p "$NODEDIR"
+        (
+          cd "$NODEDIR"
+          npm init -y >/dev/null
+          npm install --ignore-scripts --no-audit --no-fund \
+            "${MODULE_NAME}@${MODULE_VERSION}"
+        )
+        dst="$NODEDIR/node_modules/${MODULE_NAME}/prebuilds/${TARGET}"
+        mkdir -p "$dst"
+        cp "$RUNNER_TEMP"/prebuild/*.node "$dst/"
+        echo "Prebuild placed under $dst:"
+        ls -la "$dst"
+
+    - name: Place main.js and test.js
+      shell: bash
+      env:
+        MODULE_NAME: ${{ inputs.module_name }}
+        TEST_SCRIPT: ${{ inputs.test_script }}
+        NODEDIR: ${{ inputs.nodejs_project_dir }}
+        WRAPPER: ${{ github.action_path }}/wrapper.js
+        SMOKE_TEMPLATE: ${{ github.action_path }}/default-smoke-test.js
+      run: |
+        set -euo pipefail
+        # main.js is always the wrapper: it installs the exit-sentinel handler
+        # and then delegates to ./test.js.
+        cp "$WRAPPER" "$NODEDIR/main.js"
+
+        # test.js is either the caller's script or a generated smoke test.
+        if [ -z "$TEST_SCRIPT" ]; then
+          echo "No test_script provided; using default smoke-test template."
+          esc=$(printf '%s' "$MODULE_NAME" | sed 's/[\\/&]/\\&/g')
+          sed "s/__MODULE_NAME__/$esc/g" "$SMOKE_TEMPLATE" > "$NODEDIR/test.js"
+        elif [ ! -f "$TEST_SCRIPT" ]; then
+          echo "::error::test_script '$TEST_SCRIPT' not found in caller repo"
+          exit 1
+        else
+          cp "$TEST_SCRIPT" "$NODEDIR/test.js"
+        fi
+        echo "main.js (wrapper) + test.js placed under $NODEDIR/"

--- a/.github/actions/assemble-test-project/default-smoke-test.js
+++ b/.github/actions/assemble-test-project/default-smoke-test.js
@@ -1,0 +1,23 @@
+// Template for the default smoke test used by the `assemble-test-project`
+// composite action when the caller does not provide a `test_script`.
+// `__MODULE_NAME__` is substituted with the module name at CI time.
+
+try {
+  require('__MODULE_NAME__')
+  console.log('TAP version 13')
+  console.log('1..1')
+  console.log('ok 1 - require(__MODULE_NAME__) succeeded')
+  process.exit(0)
+} catch (err) {
+  console.log('TAP version 13')
+  console.log('1..1')
+  console.log('not ok 1 - require(__MODULE_NAME__) threw')
+  console.log('  ---')
+  console.log('  message: ' + JSON.stringify(err && err.message))
+  console.log('  stack: |')
+  for (const line of String((err && err.stack) || err).split('\n')) {
+    console.log('    ' + line)
+  }
+  console.log('  ...')
+  process.exit(1)
+}

--- a/.github/actions/assemble-test-project/wrapper.js
+++ b/.github/actions/assemble-test-project/wrapper.js
@@ -1,0 +1,16 @@
+// Entry point placed as `main.js` inside the test-harness's nodejs-project.
+// Installs a process `exit` handler that prints the `__NODE_EXIT__:<code>`
+// sentinel the CI workflow greps for, then hands off to the test script.
+//
+// The handler is needed because `process.exit()` inside node calls libc
+// `exit()` directly, which terminates the whole app/process without the
+// native harness's post-`node_start` code ever running. `process.on('exit')`
+// fires synchronously before the exit, so the sentinel still lands in stdout
+// (streamed through `simctl launch --console-pty` on iOS, or through the
+// stdout-to-logcat pump on Android).
+
+process.on('exit', (code) => {
+  process.stdout.write('__NODE_EXIT__:' + code + '\n')
+})
+
+require('./test.js')

--- a/.github/actions/prebuild/action.yml
+++ b/.github/actions/prebuild/action.yml
@@ -13,6 +13,10 @@ inputs:
     description: "The architecture to prebuild for"
     required: true
     default: "arm64"
+  simulator:
+    description: "Build for a simulator (iOS only). Accepts 'true' or 'false'."
+    required: false
+    default: "false"
   module_version:
     description: "The version of the module to prebuild"
     required: false
@@ -31,21 +35,48 @@ outputs:
   module_version:
     description: "The resolved version of the module"
     value: ${{ steps.parse-module-version.outputs.version }}
+  target:
+    description: "The prebuild target name (e.g. 'ios-arm64-simulator')"
+    value: ${{ steps.target.outputs.target }}
 
 runs:
   using: "composite"
   steps:
-    - name: Validate runner for platform
+    - name: Validate platform/arch/simulator combination
       shell: bash
       run: |
-        case "${{ inputs.platform }}" in
+        platform="${{ inputs.platform }}"
+        arch="${{ inputs.arch }}"
+        simulator="${{ inputs.simulator }}"
+
+        case "$platform" in
           ios|macos)
             if [ "$RUNNER_OS" != "macOS" ]; then
-              echo "::error::Platform '${{ inputs.platform }}' requires a macOS runner, but runner is '$RUNNER_OS'. Set 'runs-on: macos-latest' (or similar) in the calling job."
+              echo "::error::Platform '$platform' requires a macOS runner, but runner is '$RUNNER_OS'. Set 'runs-on: macos-latest' (or similar) in the calling job."
               exit 1
             fi
             ;;
         esac
+
+        if [ "$simulator" = "true" ] && [ "$platform" != "ios" ]; then
+          echo "::error::simulator=true is only valid for platform=ios"
+          exit 1
+        fi
+
+        if [ "$platform" = "ios" ] && [ "$arch" = "x64" ] && [ "$simulator" != "true" ]; then
+          echo "::error::ios + x64 requires simulator=true (iOS devices are arm64-only)"
+          exit 1
+        fi
+
+    - name: Compute target suffix
+      id: target
+      shell: bash
+      run: |
+        suffix=""
+        if [ "${{ inputs.simulator }}" = "true" ]; then
+          suffix="-simulator"
+        fi
+        echo "target=${{ inputs.platform }}-${{ inputs.arch }}${suffix}" >> $GITHUB_OUTPUT
 
     - name: Use Node.js ${{ inputs.node_version }}
       uses: actions/setup-node@v6
@@ -101,6 +132,20 @@ runs:
             extra_args+=(-D CMAKE_SHARED_LINKER_FLAGS="-Wl,-z,max-page-size=16384")
             ;;
         esac
+        case "${{ inputs.platform }}" in
+          android)
+            # bare-make's Android toolchain defaults ANDROID_STL=none, which
+            # passes -nostdinc++ and breaks modules that include any C++ stdlib
+            # header (e.g. sodium-native >=5.x via libjstl). c++_static is a
+            # no-op for pure-C modules and self-contained for C++ ones; switch
+            # to c++_shared if binary-size dedup across multiple native modules
+            # becomes worth the app-side packaging work.
+            extra_args+=(-D ANDROID_STL=c++_static)
+            ;;
+        esac
+        if [ "${{ inputs.simulator }}" = "true" ]; then
+          extra_args+=(--simulator)
+        fi
         bare-make generate \
           --platform ${{ inputs.platform }} \
           --arch ${{ inputs.arch }} \
@@ -121,7 +166,6 @@ runs:
       with:
         name:
           ${{ inputs.module_name }}-${{
-          steps.parse-module-version.outputs.version }}-${{ inputs.platform
-          }}-${{ inputs.arch }}
-        path:
-          ./package/prebuilds/${{ inputs.platform }}-${{ inputs.arch }}/*.node
+          steps.parse-module-version.outputs.version }}-${{
+          steps.target.outputs.target }}
+        path: ./package/prebuilds/${{ steps.target.outputs.target }}/*.node

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -24,6 +24,11 @@ on:
           - "x64"
           - "arm"
         default: "arm64"
+      simulator:
+        type: boolean
+        description: "Build for an iOS simulator (ios only)"
+        required: false
+        default: false
       module_version:
         type: string
         description: "The version of the module to prebuild"
@@ -33,15 +38,6 @@ on:
         type: string
         description: "Path to patch file to apply to the module (optional)"
         required: false
-      runner:
-        type: choice
-        description: "The runner to use for the build"
-        required: true
-        options:
-          - "ubuntu-22.04"
-          - "macos-latest"
-          - "windows-latest"
-        default: "ubuntu-22.04"
   workflow_call:
     inputs:
       module_name:
@@ -58,6 +54,11 @@ on:
         description: "The architecture to prebuild for"
         required: true
         default: "arm64"
+      simulator:
+        type: boolean
+        description: "Build for an iOS simulator (ios only)"
+        required: false
+        default: false
       module_version:
         type: string
         description: "The version of the module to prebuild"
@@ -67,11 +68,6 @@ on:
         type: string
         description: "Path to patch file to apply to the module (optional)"
         required: false
-      runner:
-        type: string
-        description: "The runner to use for the build"
-        required: true
-        default: "ubuntu-22.04"
     outputs:
       module_version:
         description: "The version of the module"
@@ -79,9 +75,9 @@ on:
 
 jobs:
   build:
-    runs-on: ${{ inputs.runner }}
+    runs-on: ${{ inputs.platform == 'ios' && 'macos-latest' || 'ubuntu-22.04' }}
     timeout-minutes: 10
-    name: ${{ inputs.module_name }} (${{ inputs.platform }}-${{ inputs.arch }})
+    name: ${{ inputs.module_name }} (${{ inputs.platform }}-${{ inputs.arch }}${{ inputs.simulator && '-simulator' || '' }})
     outputs:
       module_version: ${{ steps.prebuild.outputs.module_version }}
     steps:
@@ -93,5 +89,6 @@ jobs:
           module_name: ${{ inputs.module_name }}
           platform: ${{ inputs.platform }}
           arch: ${{ inputs.arch }}
+          simulator: ${{ inputs.simulator }}
           module_version: ${{ inputs.module_version }}
           patch_file: ${{ inputs.patch_file }}

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -1,0 +1,198 @@
+name: Test on Android emulator
+
+on:
+  workflow_call:
+    inputs:
+      module_name:
+        type: string
+        description: "The npm module being tested (e.g. 'sodium-native')"
+        required: true
+      module_version:
+        type: string
+        description: "Version of the module to install (e.g. '1.0.0' or 'latest')"
+        required: true
+      artifact_name:
+        type: string
+        description: "Name of the prebuild artifact uploaded earlier in the run"
+        required: true
+      target:
+        type: string
+        description: "Prebuild target key, e.g. 'android-x64' (must match emulator arch)"
+        required: false
+        default: "android-x64"
+      test_script:
+        type: string
+        description: |
+          Path to the test script (relative to the caller repo root). The
+          script will run as the main.js inside nodejs-mobile and should emit
+          TAP on stdout. If empty (the default), a minimal script is generated
+          that just does `require('<module_name>')` as a smoke test.
+        required: false
+        default: ""
+      nodejs_mobile_version:
+        type: string
+        description: "nodejs-mobile release tag to download libnode from"
+        required: false
+        default: "v18.20.4"
+      api_level:
+        type: number
+        description: "Android API level for the emulator"
+        required: false
+        default: 30
+      emulator_arch:
+        type: string
+        description: "Emulator arch (must match the prebuild target's arch)"
+        required: false
+        default: "x86_64"
+      harness_ref:
+        type: string
+        description: "Ref of digidem/nodejs-mobile-bare-prebuilds to pull the harness from"
+        required: false
+        default: "main"
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - name: Checkout caller repo
+        uses: actions/checkout@v4
+
+      - name: Checkout test harness
+        uses: actions/checkout@v4
+        with:
+          repository: digidem/nodejs-mobile-bare-prebuilds
+          ref: ${{ inputs.harness_ref }}
+          path: .nodejs-mobile-bare-prebuilds
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - uses: android-actions/setup-android@v3
+
+      - name: Enable KVM
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+
+      - name: Cache nodejs-mobile android binaries
+        id: cache-libnode
+        uses: actions/cache@v4
+        with:
+          path: .nodejs-mobile-bare-prebuilds/test-harness/android/app/libnode
+          key: libnode-android-${{ inputs.nodejs_mobile_version }}
+
+      - name: Download nodejs-mobile android libraries
+        if: steps.cache-libnode.outputs.cache-hit != 'true'
+        env:
+          NM_VERSION: ${{ inputs.nodejs_mobile_version }}
+        run: |
+          set -euo pipefail
+          harness=.nodejs-mobile-bare-prebuilds/test-harness/android
+          tmp=$(mktemp -d)
+          url="https://github.com/nodejs-mobile/nodejs-mobile/releases/download/${NM_VERSION}/nodejs-mobile-${NM_VERSION}-android.zip"
+          echo "Downloading $url"
+          curl -fL "$url" -o "$tmp/libnode.zip"
+          unzip -q "$tmp/libnode.zip" -d "$tmp/libnode"
+          mkdir -p "$harness/app/libnode"
+          # Zip layout: include/node/*.h, bin/<abi>/libnode.so
+          cp -R "$tmp/libnode/include" "$harness/app/libnode/"
+          cp -R "$tmp/libnode/bin"     "$harness/app/libnode/"
+
+      - name: Assemble nodejs-project
+        uses: ./.nodejs-mobile-bare-prebuilds/.github/actions/assemble-test-project
+        with:
+          module_name: ${{ inputs.module_name }}
+          module_version: ${{ inputs.module_version }}
+          artifact_name: ${{ inputs.artifact_name }}
+          target: ${{ inputs.target }}
+          test_script: ${{ inputs.test_script }}
+          nodejs_project_dir: .nodejs-mobile-bare-prebuilds/test-harness/android/app/src/main/assets/nodejs-project
+
+      - uses: gradle/actions/setup-gradle@v4
+        with:
+          gradle-version: "8.9"
+
+      - name: Build APK
+        working-directory: .nodejs-mobile-bare-prebuilds/test-harness/android
+        env:
+          ABI: ${{ inputs.emulator_arch }}
+        run: gradle -PabiFilter=${ABI} :app:assembleDebug --no-daemon
+
+      - name: Cache AVD
+        uses: actions/cache@v4
+        id: avd-cache
+        with:
+          path: |
+            ~/.android/avd/*
+            ~/.android/adb*
+          key: avd-api${{ inputs.api_level }}-${{ inputs.emulator_arch }}-v1
+
+      - name: Generate AVD snapshot
+        if: steps.avd-cache.outputs.cache-hit != 'true'
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ inputs.api_level }}
+          target: google_atd
+          arch: ${{ inputs.emulator_arch }}
+          force-avd-creation: false
+          ram-size: 4096M
+          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          disable-animations: false
+          script: echo "AVD cached"
+
+      - name: Run test on emulator
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: ${{ inputs.api_level }}
+          target: google_atd
+          arch: ${{ inputs.emulator_arch }}
+          force-avd-creation: false
+          ram-size: 4096M
+          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim
+          disable-animations: false
+          script: |
+            set -euo pipefail
+            APK=.nodejs-mobile-bare-prebuilds/test-harness/android/app/build/outputs/apk/debug/app-debug.apk
+
+            adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done'
+            adb install -r -g "$APK"
+            adb logcat -c
+
+            # Launch the activity. The app pumps node's stdout/stderr to
+            # logcat tag NODEJS-MOBILE and emits __NODE_EXIT__:<code> when done.
+            adb shell am start -W -n com.digidem.nodejstest/.TestActivity
+
+            # Stream logcat; awk echoes each line (so TAP lands in the workflow
+            # log) and captures the exit code from the sentinel.
+            : > /tmp/node_exit
+            set +e
+            timeout 1200 adb logcat -v raw -s NODEJS-MOBILE:V | awk '
+              { print }
+              /__NODE_EXIT__:/ {
+                if (match($0, /__NODE_EXIT__:-?[0-9]+/)) {
+                  s = substr($0, RSTART, RLENGTH)
+                  sub(/^__NODE_EXIT__:/, "", s)
+                  print "NODE_EXIT_CODE=" s > "/tmp/node_exit"
+                  close("/tmp/node_exit")
+                  exit
+                }
+              }
+            '
+            set -e
+
+            if [ ! -s /tmp/node_exit ]; then
+              echo "::error::Did not observe __NODE_EXIT__ sentinel within timeout"
+              exit 1
+            fi
+            # shellcheck disable=SC1091
+            . /tmp/node_exit
+            echo "Node process exited with code ${NODE_EXIT_CODE}"
+            exit "${NODE_EXIT_CODE}"

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -1,0 +1,188 @@
+name: Test on iOS simulator
+
+on:
+  workflow_call:
+    inputs:
+      module_name:
+        type: string
+        description: "The npm module being tested (e.g. 'sodium-native')"
+        required: true
+      module_version:
+        type: string
+        description: "Version of the module to install"
+        required: true
+      artifact_name:
+        type: string
+        description: "Name of the prebuild artifact uploaded earlier in the run"
+        required: true
+      target:
+        type: string
+        description: |
+          The `prebuilds/<target>/` subfolder to install the .node file into
+          — this is what the runtime loader (require-addon / bare-addon-resolve)
+          will look for, derived from `process.platform + '-' + process.arch`.
+          On the iOS simulator this is always 'ios-arm64' (no -simulator
+          suffix), even if the prebuild was built with simulator=true.
+        required: false
+        default: "ios-arm64"
+      test_script:
+        type: string
+        description: |
+          Path to the test script (relative to the caller repo root). The
+          script will run as the main.js inside nodejs-mobile and should emit
+          TAP on stdout. If empty (the default), a minimal script is generated
+          that just does `require('<module_name>')` as a smoke test.
+        required: false
+        default: ""
+      nodejs_mobile_version:
+        type: string
+        description: "nodejs-mobile release tag to download NodeMobile.xcframework from"
+        required: false
+        default: "v18.20.4"
+      simulator_name:
+        type: string
+        description: "Name of the iOS Simulator device to boot"
+        required: false
+        default: "iPhone 15"
+      harness_ref:
+        type: string
+        description: "Ref of digidem/nodejs-mobile-bare-prebuilds to pull the harness from"
+        required: false
+        default: "main"
+
+jobs:
+  test:
+    # macos-14 / macos-latest runners are Apple Silicon (arm64) — the
+    # simulator will run arm64 code, so the matching prebuild target is
+    # ios-arm64-simulator.
+    runs-on: macos-14
+    timeout-minutes: 45
+    steps:
+      - name: Checkout caller repo
+        uses: actions/checkout@v4
+
+      - name: Checkout test harness
+        uses: actions/checkout@v4
+        with:
+          repository: digidem/nodejs-mobile-bare-prebuilds
+          ref: ${{ inputs.harness_ref }}
+          path: .nodejs-mobile-bare-prebuilds
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Cache NodeMobile xcframework
+        id: cache-nodemobile
+        uses: actions/cache@v4
+        with:
+          path: .nodejs-mobile-bare-prebuilds/test-harness/ios/NodeMobile
+          key: nodemobile-${{ inputs.nodejs_mobile_version }}
+
+      - name: Download nodejs-mobile iOS xcframework
+        if: steps.cache-nodemobile.outputs.cache-hit != 'true'
+        env:
+          NM_VERSION: ${{ inputs.nodejs_mobile_version }}
+        run: |
+          set -euo pipefail
+          harness=.nodejs-mobile-bare-prebuilds/test-harness/ios
+          tmp=$(mktemp -d)
+          url="https://github.com/nodejs-mobile/nodejs-mobile/releases/download/${NM_VERSION}/nodejs-mobile-${NM_VERSION}-ios.zip"
+          echo "Downloading $url"
+          curl -fL "$url" -o "$tmp/ios.zip"
+          unzip -q "$tmp/ios.zip" -d "$tmp/ios"
+          # The pbxproj references `NodeMobile/NodeMobile.xcframework`; Xcode
+          # picks the right slice for the active -sdk at build time.
+          mkdir -p "$harness/NodeMobile"
+          cp -R "$tmp/ios/NodeMobile.xcframework" "$harness/NodeMobile/"
+          ls -la "$harness/NodeMobile/NodeMobile.xcframework" | head
+
+      - name: Assemble nodejs-project
+        uses: ./.nodejs-mobile-bare-prebuilds/.github/actions/assemble-test-project
+        with:
+          module_name: ${{ inputs.module_name }}
+          module_version: ${{ inputs.module_version }}
+          artifact_name: ${{ inputs.artifact_name }}
+          target: ${{ inputs.target }}
+          test_script: ${{ inputs.test_script }}
+          nodejs_project_dir: .nodejs-mobile-bare-prebuilds/test-harness/ios/nodejs-project
+
+      - name: Build TestHarness.app
+        working-directory: .nodejs-mobile-bare-prebuilds/test-harness/ios
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -project TestHarness.xcodeproj \
+            -scheme TestHarness \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath build \
+            CODE_SIGNING_ALLOWED=NO \
+            ARCHS=arm64 \
+            ONLY_ACTIVE_ARCH=NO \
+            build
+          # Surface the built app path.
+          find build/Build/Products -maxdepth 3 -name 'TestHarness.app'
+
+      - name: Boot simulator
+        env:
+          SIM_NAME: ${{ inputs.simulator_name }}
+        run: |
+          set -euo pipefail
+          # Pick the newest runtime matching the requested device, boot it.
+          DEVICE_ID=$(xcrun simctl list devices available -j | \
+            python3 -c "
+          import json, sys, os
+          d = json.load(sys.stdin)
+          want = os.environ['SIM_NAME']
+          picks = []
+          for runtime, devs in d['devices'].items():
+            for dev in devs:
+              if dev.get('name') == want and dev.get('isAvailable'):
+                picks.append((runtime, dev['udid']))
+          picks.sort()  # newest runtime sorts last
+          if not picks:
+            sys.exit('No available simulator named ' + want)
+          print(picks[-1][1])
+          ")
+          echo "DEVICE_ID=$DEVICE_ID" >> $GITHUB_ENV
+          xcrun simctl boot "$DEVICE_ID" || true
+          xcrun simctl bootstatus "$DEVICE_ID" -b
+
+      - name: Install & launch test app, stream stdout
+        working-directory: .nodejs-mobile-bare-prebuilds/test-harness/ios
+        run: |
+          set -euo pipefail
+          APP=$(find build/Build/Products -maxdepth 3 -name 'TestHarness.app' | head -1)
+          echo "App: $APP"
+          xcrun simctl install "$DEVICE_ID" "$APP"
+
+          : > /tmp/node_exit
+          set +e
+          # --console-pty attaches a pty to the app's stdout/stderr and blocks
+          # until the app terminates. The app prints `__NODE_EXIT__:<code>`
+          # and calls exit(). The job-level timeout-minutes caps total runtime.
+          xcrun simctl launch --console-pty --terminate-running-process \
+              "$DEVICE_ID" com.digidem.nodejstest 2>&1 | awk '
+            { print }
+            /__NODE_EXIT__:/ {
+              if (match($0, /__NODE_EXIT__:-?[0-9]+/)) {
+                s = substr($0, RSTART, RLENGTH)
+                sub(/^__NODE_EXIT__:/, "", s)
+                print "NODE_EXIT_CODE=" s > "/tmp/node_exit"
+                close("/tmp/node_exit")
+                exit
+              }
+            }
+          '
+          set -e
+
+          if [ ! -s /tmp/node_exit ]; then
+            echo "::error::Did not observe __NODE_EXIT__ sentinel within timeout"
+            exit 1
+          fi
+          # shellcheck disable=SC1091
+          . /tmp/node_exit
+          echo "Node process exited with code ${NODE_EXIT_CODE}"
+          exit "${NODE_EXIT_CODE}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,92 @@
+name: End-to-end test (manual dispatch)
+
+# Manual wrapper that chains prebuild -> test for one or both platforms so the
+# whole pipeline can be exercised from the Actions tab without needing to call
+# these reusable workflows from another repo.
+#
+# The harness is always checked out at the same commit as this dispatch run
+# (`harness_ref: ${{ github.sha }}`), so in-flight changes to the harness or
+# the composite action are tested as-is on the triggering branch.
+
+on:
+  workflow_dispatch:
+    inputs:
+      module_name:
+        type: string
+        description: "npm module to build and test (e.g. 'sodium-native')"
+        required: true
+        default: "quickbit-native"
+      module_version:
+        type: string
+        description: "Version of the module to fetch from npm"
+        required: false
+        default: "latest"
+      platforms:
+        type: choice
+        description: "Which platform(s) to run the pipeline against"
+        required: true
+        options:
+          - both
+          - android
+          - ios
+        default: both
+      test_script:
+        type: string
+        description: "(Optional) path to a test script in this repo; blank uses the default require() smoke test"
+        required: false
+        default: ""
+      patch_file:
+        type: string
+        description: "(Optional) path to a patch file to apply to the module before building"
+        required: false
+        default: ""
+
+jobs:
+  build-android:
+    if: ${{ inputs.platforms == 'both' || inputs.platforms == 'android' }}
+    uses: ./.github/workflows/prebuild.yml
+    with:
+      module_name: ${{ inputs.module_name }}
+      platform: android
+      arch: x64
+      module_version: ${{ inputs.module_version }}
+      patch_file: ${{ inputs.patch_file }}
+
+  test-android:
+    if: ${{ inputs.platforms == 'both' || inputs.platforms == 'android' }}
+    needs: build-android
+    uses: ./.github/workflows/test-android.yml
+    with:
+      module_name: ${{ inputs.module_name }}
+      module_version: ${{ needs.build-android.outputs.module_version }}
+      artifact_name: ${{ inputs.module_name }}-${{ needs.build-android.outputs.module_version }}-android-x64
+      target: android-x64
+      test_script: ${{ inputs.test_script }}
+      harness_ref: ${{ github.sha }}
+
+  build-ios:
+    if: ${{ inputs.platforms == 'both' || inputs.platforms == 'ios' }}
+    uses: ./.github/workflows/prebuild.yml
+    with:
+      module_name: ${{ inputs.module_name }}
+      platform: ios
+      arch: arm64
+      simulator: true
+      module_version: ${{ inputs.module_version }}
+      patch_file: ${{ inputs.patch_file }}
+
+  test-ios:
+    if: ${{ inputs.platforms == 'both' || inputs.platforms == 'ios' }}
+    needs: build-ios
+    uses: ./.github/workflows/test-ios.yml
+    with:
+      module_name: ${{ inputs.module_name }}
+      module_version: ${{ needs.build-ios.outputs.module_version }}
+      # Prebuild artifacts from simulator builds are named '…-ios-arm64-simulator',
+      # but the test workflow installs them under prebuilds/ios-arm64/ because
+      # at runtime nodejs-mobile reports process.platform+'-'+process.arch as
+      # 'ios-arm64' regardless of simulator vs device.
+      artifact_name: ${{ inputs.module_name }}-${{ needs.build-ios.outputs.module_version }}-ios-arm64-simulator
+      target: ios-arm64
+      test_script: ${{ inputs.test_script }}
+      harness_ref: ${{ github.sha }}

--- a/README.md
+++ b/README.md
@@ -94,6 +94,78 @@ The `.github/workflows/prebuild.yml` workflow in this repository is kept as a
 thin wrapper around the composite action so the build can be triggered manually
 from the Actions tab for debugging.
 
+## Testing prebuilds on an emulator / simulator
+
+Two reusable workflows run the built `.node` file inside nodejs-mobile on a
+real emulator / simulator to catch runtime issues the prebuild step cannot
+(wrong page size, missing symbols, `require-addon` not finding the binary,
+etc.).
+
+The caller's repo provides a `test.js` that outputs TAP; the workflow bundles
+it with the artifact and the module-under-test into a minimal native app,
+installs it on an emulator / simulator, streams the app's stdout into the
+workflow log, and passes/fails on the Node exit code.
+
+If `test_script` is omitted, a minimal smoke test is generated that just does
+`require('<module_name>')` and exits non-zero if it throws — enough to catch
+linker / load-time breakage without the caller needing to write any JS.
+
+```yaml
+jobs:
+  build-android-x64:
+    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/prebuild.yml@main
+    with:
+      module_name: sodium-native
+      platform: android
+      arch: x64
+
+  test-android:
+    needs: build-android-x64
+    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/test-android.yml@main
+    with:
+      module_name: sodium-native
+      module_version: ${{ needs.build-android-x64.outputs.module_version }}
+      artifact_name: sodium-native-${{ needs.build-android-x64.outputs.module_version }}-android-x64
+      target: android-x64    # the prebuilds/<dir>/ to install into
+      # test_script: test.js   # omit to get a default require() smoke test   # caller-repo path; outputs TAP on stdout
+
+  build-ios-sim-arm64:
+    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/prebuild.yml@main
+    with:
+      module_name: sodium-native
+      platform: ios
+      arch: arm64
+      simulator: true
+
+  test-ios:
+    needs: build-ios-sim-arm64
+    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/test-ios.yml@main
+    with:
+      module_name: sodium-native
+      module_version: ${{ needs.build-ios-sim-arm64.outputs.module_version }}
+      artifact_name: sodium-native-${{ needs.build-ios-sim-arm64.outputs.module_version }}-ios-arm64-simulator
+      # At runtime on the simulator nodejs-mobile reports platform+arch as
+      # 'ios-arm64' (no -simulator suffix), so the .node file is installed
+      # under prebuilds/ios-arm64/. Leave `target` at its default.
+      # test_script: test.js   # omit to get a default require() smoke test
+```
+
+The native shells used by the test workflows live under
+[test-harness/android/](test-harness/android/) and
+[test-harness/ios/](test-harness/ios/). They each load the module-under-test,
+run `test.js` as the main script, pipe stdout/stderr back to the workflow log
+(logcat on Android, `simctl launch --console-pty` on iOS), and emit a
+`__NODE_EXIT__:<code>` sentinel the workflow parses to set pass/fail.
+
+### Manual dispatch
+
+The [.github/workflows/test.yml](.github/workflows/test.yml) workflow chains
+`prebuild.yml` → `test-*.yml` behind a `workflow_dispatch` trigger so the whole
+pipeline can be exercised from the Actions tab without a caller repo. The
+harness is checked out at the same commit as the dispatch run, so in-flight
+changes on a branch are tested as-is. Platforms can be selected individually
+or together.
+
 ## Contributing
 
 We welcome contributions to this repository. If you have an idea for a new

--- a/test-harness/android/.gitignore
+++ b/test-harness/android/.gitignore
@@ -1,0 +1,39 @@
+# Based on https://github.com/github/gitignore/blob/main/Android.gitignore,
+# trimmed to what applies to this harness.
+
+# Gradle
+.gradle/
+build/
+
+# Local configuration (SDK path, etc)
+local.properties
+
+# Log/OS files
+*.log
+.DS_Store
+
+# Android Studio / AGP generated
+captures/
+.externalNativeBuild/
+.cxx/
+*.apk
+*.aab
+*.aar
+*.ap_
+*.dex
+output-metadata.json
+
+# IntelliJ / Android Studio project metadata
+*.iml
+.idea/
+
+# Keystores (this harness builds unsigned debug only)
+*.jks
+*.keystore
+
+# Profiling
+*.hprof
+
+# CI-populated — the workflow fills these at runtime and shouldn't be committed.
+app/libnode/
+app/src/main/assets/

--- a/test-harness/android/README.md
+++ b/test-harness/android/README.md
@@ -1,0 +1,22 @@
+# Android test harness
+
+A minimal Android app that embeds nodejs-mobile, runs a `main.js` from its
+assets, pumps Node's stdout/stderr to logcat (tag `NODEJS-MOBILE`), emits an
+`__NODE_EXIT__:<code>` sentinel line, and terminates the process.
+
+This is not a user-facing app — it exists so the reusable workflow
+`.github/workflows/test-android.yml` can build an APK, install it on an
+emulator, and read back TAP output + pass/fail from logcat.
+
+## Populated at CI time
+
+- `app/libnode/include/node/` — nodejs-mobile header files
+- `app/libnode/bin/<abi>/libnode.so` — prebuilt libnode
+- `app/src/main/assets/nodejs-project/` — the module-under-test's
+  `node_modules/` tree plus a `main.js` that runs the caller's test script
+
+## Build
+
+```
+ANDROID_SDK_ROOT=$ANDROID_HOME gradle -PabiFilter=x86_64 :app:assembleDebug
+```

--- a/test-harness/android/app/build.gradle
+++ b/test-harness/android/app/build.gradle
@@ -1,0 +1,53 @@
+plugins {
+    id 'com.android.application'
+}
+
+android {
+    namespace 'com.digidem.nodejstest'
+    compileSdk 34
+    ndkVersion '26.3.11579264'
+
+    defaultConfig {
+        applicationId "com.digidem.nodejstest"
+        minSdk 24
+        targetSdk 34
+        versionCode 1
+        versionName "1.0"
+        externalNativeBuild {
+            cmake {
+                arguments "-DANDROID_STL=c++_shared"
+            }
+        }
+        ndk {
+            // ABI filter is set at build time via -PabiFilter=<abi>
+            abiFilters project.findProperty("abiFilter") ?: "x86_64"
+        }
+    }
+
+    externalNativeBuild {
+        cmake {
+            path "src/main/cpp/CMakeLists.txt"
+        }
+    }
+
+    sourceSets {
+        main {
+            // libnode/bin/<abi>/libnode.so is populated at CI time
+            jniLibs.srcDirs 'libnode/bin/'
+        }
+    }
+
+    buildTypes {
+        debug {
+            // Keep debug build simple: no minification, no shrinking.
+            minifyEnabled false
+        }
+    }
+
+    packagingOptions {
+        jniLibs {
+            // libnode.so is large; don't compress so it can be mmap'd
+            useLegacyPackaging true
+        }
+    }
+}

--- a/test-harness/android/app/src/main/AndroidManifest.xml
+++ b/test-harness/android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:label="nodejs-test"
+        android:extractNativeLibs="true"
+        android:hasCode="true">
+        <activity
+            android:name=".TestActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/test-harness/android/app/src/main/cpp/CMakeLists.txt
+++ b/test-harness/android/app/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,17 @@
+cmake_minimum_required(VERSION 3.18.1)
+project(native-lib)
+
+# libnode/include/node/ is populated at CI time from the nodejs-mobile release.
+include_directories(${CMAKE_SOURCE_DIR}/../../../libnode/include/node/)
+
+add_library(native-lib SHARED native-lib.cpp)
+
+# libnode.so is pre-built and placed under ../../../libnode/bin/<abi>/ at CI time.
+add_library(libnode SHARED IMPORTED)
+set_target_properties(libnode PROPERTIES
+    IMPORTED_LOCATION
+    ${CMAKE_SOURCE_DIR}/../../../libnode/bin/${ANDROID_ABI}/libnode.so)
+
+find_library(log-lib log)
+
+target_link_libraries(native-lib libnode ${log-lib})

--- a/test-harness/android/app/src/main/cpp/native-lib.cpp
+++ b/test-harness/android/app/src/main/cpp/native-lib.cpp
@@ -1,0 +1,102 @@
+#include <jni.h>
+#include <string>
+#include <cstdlib>
+#include <cstring>
+#include <pthread.h>
+#include <unistd.h>
+#include <android/log.h>
+#include "node.h"
+
+// Redirect node's stdout/stderr to logcat so TAP output shows up under
+// `adb logcat -s NODEJS-MOBILE:I`.
+static const char *LOGTAG = "NODEJS-MOBILE";
+static int pipe_stdout[2];
+static int pipe_stderr[2];
+static pthread_t thread_stdout;
+static pthread_t thread_stderr;
+
+static void *pump(int fd, android_LogPriority prio) {
+    char buf[2048];
+    ssize_t n;
+    while ((n = read(fd, buf, sizeof(buf) - 1)) > 0) {
+        // Split on newlines so each line becomes its own logcat entry,
+        // otherwise TAP output gets jumbled inside a single log line.
+        buf[n] = '\0';
+        char *start = buf;
+        for (char *p = buf; p < buf + n; p++) {
+            if (*p == '\n') {
+                *p = '\0';
+                __android_log_write(prio, LOGTAG, start);
+                start = p + 1;
+            }
+        }
+        if (start < buf + n) {
+            __android_log_write(prio, LOGTAG, start);
+        }
+    }
+    return NULL;
+}
+
+static void *thread_stdout_func(void *) { return pump(pipe_stdout[0], ANDROID_LOG_INFO); }
+static void *thread_stderr_func(void *) { return pump(pipe_stderr[0], ANDROID_LOG_ERROR); }
+
+static int start_redirecting_stdout_stderr() {
+    setvbuf(stdout, 0, _IONBF, 0);
+    if (pipe(pipe_stdout) != 0) return -1;
+    dup2(pipe_stdout[1], STDOUT_FILENO);
+
+    setvbuf(stderr, 0, _IONBF, 0);
+    if (pipe(pipe_stderr) != 0) return -1;
+    dup2(pipe_stderr[1], STDERR_FILENO);
+
+    if (pthread_create(&thread_stdout, 0, thread_stdout_func, 0) != 0) return -1;
+    pthread_detach(thread_stdout);
+    if (pthread_create(&thread_stderr, 0, thread_stderr_func, 0) != 0) return -1;
+    pthread_detach(thread_stderr);
+    return 0;
+}
+
+extern "C" JNIEXPORT jint JNICALL
+Java_com_digidem_nodejstest_TestActivity_startNodeWithArguments(
+        JNIEnv *env,
+        jobject /* this */,
+        jobjectArray arguments) {
+
+    jsize argc = env->GetArrayLength(arguments);
+
+    // libuv requires all argv strings to live in one contiguous allocation.
+    int total = 0;
+    for (int i = 0; i < argc; i++) {
+        total += strlen(env->GetStringUTFChars(
+            (jstring)env->GetObjectArrayElement(arguments, i), 0));
+        total++;
+    }
+    char *args_buffer = (char *)calloc(total, sizeof(char));
+    char *argv[argc];
+    char *cursor = args_buffer;
+    for (int i = 0; i < argc; i++) {
+        const char *s = env->GetStringUTFChars(
+            (jstring)env->GetObjectArrayElement(arguments, i), 0);
+        strncpy(cursor, s, strlen(s));
+        argv[i] = cursor;
+        cursor += strlen(cursor) + 1;
+    }
+
+    if (start_redirecting_stdout_stderr() == -1) {
+        __android_log_write(ANDROID_LOG_ERROR, LOGTAG,
+            "Couldn't redirect stdout/stderr to logcat.");
+    }
+
+    int rc = node::Start(argc, argv);
+    free(args_buffer);
+    return (jint)rc;
+}
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_digidem_nodejstest_TestActivity_logExitSentinel(
+        JNIEnv *env,
+        jobject /* this */,
+        jint code) {
+    // The CI workflow greps for this line to extract the Node exit code.
+    __android_log_print(ANDROID_LOG_INFO, LOGTAG, "__NODE_EXIT__:%d", (int)code);
+}

--- a/test-harness/android/app/src/main/java/com/digidem/nodejstest/TestActivity.java
+++ b/test-harness/android/app/src/main/java/com/digidem/nodejstest/TestActivity.java
@@ -1,0 +1,98 @@
+package com.digidem.nodejstest;
+
+import android.app.Activity;
+import android.content.res.AssetManager;
+import android.os.Bundle;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class TestActivity extends Activity {
+
+    static {
+        System.loadLibrary("node");
+        System.loadLibrary("native-lib");
+    }
+
+    private static boolean _started = false;
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+
+        if (_started) return;
+        _started = true;
+
+        final String nodeDir =
+            getApplicationContext().getFilesDir().getAbsolutePath() + "/nodejs-project";
+
+        new Thread(new Runnable() {
+            @Override
+            public void run() {
+                File nodeDirRef = new File(nodeDir);
+                if (nodeDirRef.exists()) {
+                    deleteRecursive(nodeDirRef);
+                }
+                copyAssetFolder(
+                    getApplicationContext().getAssets(),
+                    "nodejs-project",
+                    nodeDir);
+
+                int exitCode = startNodeWithArguments(new String[] {
+                    "node",
+                    nodeDir + "/main.js"
+                });
+
+                // Emit the exit sentinel so the CI runner can parse it from logcat.
+                logExitSentinel(exitCode);
+
+                // Terminate the process so `adb` / the runner sees the app exit.
+                System.exit(exitCode);
+            }
+        }, "node-main").start();
+    }
+
+    public native int startNodeWithArguments(String[] arguments);
+
+    public native void logExitSentinel(int code);
+
+    private static boolean deleteRecursive(File file) {
+        File[] children = file.listFiles();
+        if (children != null) {
+            for (File child : children) deleteRecursive(child);
+        }
+        return file.delete();
+    }
+
+    private static boolean copyAssetFolder(AssetManager am, String from, String to) {
+        try {
+            String[] files = am.list(from);
+            if (files == null || files.length == 0) {
+                return copyAsset(am, from, to);
+            }
+            new File(to).mkdirs();
+            boolean ok = true;
+            for (String f : files) {
+                ok &= copyAssetFolder(am, from + "/" + f, to + "/" + f);
+            }
+            return ok;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+
+    private static boolean copyAsset(AssetManager am, String from, String to) {
+        try (InputStream in = am.open(from);
+             OutputStream out = new FileOutputStream(to)) {
+            byte[] buf = new byte[8192];
+            int n;
+            while ((n = in.read(buf)) != -1) out.write(buf, 0, n);
+            return true;
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
+        }
+    }
+}

--- a/test-harness/android/build.gradle
+++ b/test-harness/android/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id 'com.android.application' version '8.6.1' apply false
+}

--- a/test-harness/android/gradle.properties
+++ b/test-harness/android/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2048m
+android.useAndroidX=true
+android.nonTransitiveRClass=true

--- a/test-harness/android/settings.gradle
+++ b/test-harness/android/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "nodejs-mobile-test-harness"
+include ':app'

--- a/test-harness/ios/.gitignore
+++ b/test-harness/ios/.gitignore
@@ -1,0 +1,6 @@
+build/
+DerivedData/
+*.xcuserstate
+xcuserdata/
+NodeMobile/
+nodejs-project/

--- a/test-harness/ios/README.md
+++ b/test-harness/ios/README.md
@@ -1,0 +1,30 @@
+# iOS test harness
+
+A minimal Xcode project that embeds nodejs-mobile, runs `nodejs-project/main.js`
+from the app bundle on a background thread, prints a `__NODE_EXIT__:<code>`
+sentinel line to stdout, and calls `exit()`.
+
+This is not a user-facing app — it exists so the reusable workflow
+`.github/workflows/test-ios.yml` can build `TestHarness.app`, install it on a
+simulator, launch it with `xcrun simctl launch --console-pty`, and read back
+TAP output + pass/fail from the app's stdout.
+
+## Populated at CI time
+
+- `NodeMobile/NodeMobile.xcframework` — the full xcframework from the
+  nodejs-mobile iOS release zip. Xcode's build system picks the matching
+  slice (device vs simulator) per `-sdk`.
+- `nodejs-project/` — the module-under-test's `node_modules/` tree plus a
+  `main.js` that runs the caller's test script
+
+## Build
+
+```
+xcodebuild -project TestHarness.xcodeproj \
+           -scheme TestHarness \
+           -sdk iphonesimulator \
+           -configuration Debug \
+           -destination 'generic/platform=iOS Simulator' \
+           CODE_SIGNING_ALLOWED=NO \
+           build
+```

--- a/test-harness/ios/TestHarness.xcodeproj/project.pbxproj
+++ b/test-harness/ios/TestHarness.xcodeproj/project.pbxproj
@@ -1,0 +1,367 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 48;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		33C0B28A20512E17006376A9 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 33C0B28920512E17006376A9 /* AppDelegate.m */; };
+		33C0B28D20512E17006376A9 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 33C0B28C20512E17006376A9 /* ViewController.m */; };
+		33C0B29020512E17006376A9 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 33C0B28E20512E17006376A9 /* Main.storyboard */; };
+		33C0B29220512E17006376A9 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 33C0B29120512E17006376A9 /* Assets.xcassets */; };
+		33C0B29520512E17006376A9 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 33C0B29320512E17006376A9 /* LaunchScreen.storyboard */; };
+		33C0B29820512E17006376A9 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 33C0B29720512E17006376A9 /* main.m */; };
+		33C0B29F20512ECA006376A9 /* NodeMobile.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = 33C0B29E20512ECA006376A9 /* NodeMobile.xcframework */; };
+		33C0B2A020512ECA006376A9 /* NodeMobile.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 33C0B29E20512ECA006376A9 /* NodeMobile.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		33C0B2A3205131E8006376A9 /* nodejs-project in Resources */ = {isa = PBXBuildFile; fileRef = 33C0B2A2205131E8006376A9 /* nodejs-project */; };
+		33C0B2A62051331A006376A9 /* NodeRunner.mm in Sources */ = {isa = PBXBuildFile; fileRef = 33C0B2A52051331A006376A9 /* NodeRunner.mm */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		33C0B2A120512ECA006376A9 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				33C0B2A020512ECA006376A9 /* NodeMobile.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		33C0B28520512E17006376A9 /* TestHarness.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "TestHarness.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		33C0B28820512E17006376A9 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		33C0B28920512E17006376A9 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		33C0B28B20512E17006376A9 /* ViewController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ViewController.h; sourceTree = "<group>"; };
+		33C0B28C20512E17006376A9 /* ViewController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ViewController.m; sourceTree = "<group>"; };
+		33C0B28F20512E17006376A9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		33C0B29120512E17006376A9 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		33C0B29420512E17006376A9 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		33C0B29620512E17006376A9 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		33C0B29720512E17006376A9 /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		33C0B29E20512ECA006376A9 /* NodeMobile.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = NodeMobile.xcframework; path = NodeMobile/NodeMobile.xcframework; sourceTree = "<group>"; };
+		33C0B2A2205131E8006376A9 /* nodejs-project */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "nodejs-project"; sourceTree = "<group>"; };
+		33C0B2A4205132CA006376A9 /* NodeRunner.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NodeRunner.h; sourceTree = "<group>"; };
+		33C0B2A52051331A006376A9 /* NodeRunner.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = NodeRunner.mm; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		33C0B28220512E17006376A9 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				33C0B29F20512ECA006376A9 /* NodeMobile.xcframework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		33C0B27C20512E17006376A9 = {
+			isa = PBXGroup;
+			children = (
+				33C0B2A2205131E8006376A9 /* nodejs-project */,
+				33C0B29E20512ECA006376A9 /* NodeMobile.xcframework */,
+				33C0B28720512E17006376A9 /* TestHarness */,
+				33C0B28620512E17006376A9 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		33C0B28620512E17006376A9 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				33C0B28520512E17006376A9 /* TestHarness.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		33C0B28720512E17006376A9 /* TestHarness */ = {
+			isa = PBXGroup;
+			children = (
+				33C0B28820512E17006376A9 /* AppDelegate.h */,
+				33C0B28920512E17006376A9 /* AppDelegate.m */,
+				33C0B28B20512E17006376A9 /* ViewController.h */,
+				33C0B28C20512E17006376A9 /* ViewController.m */,
+				33C0B28E20512E17006376A9 /* Main.storyboard */,
+				33C0B29120512E17006376A9 /* Assets.xcassets */,
+				33C0B29320512E17006376A9 /* LaunchScreen.storyboard */,
+				33C0B29620512E17006376A9 /* Info.plist */,
+				33C0B29720512E17006376A9 /* main.m */,
+				33C0B2A4205132CA006376A9 /* NodeRunner.h */,
+				33C0B2A52051331A006376A9 /* NodeRunner.mm */,
+			);
+			path = "TestHarness";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		33C0B28420512E17006376A9 /* TestHarness */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 33C0B29B20512E17006376A9 /* Build configuration list for PBXNativeTarget "TestHarness" */;
+			buildPhases = (
+				33C0B28120512E17006376A9 /* Sources */,
+				33C0B28220512E17006376A9 /* Frameworks */,
+				33C0B28320512E17006376A9 /* Resources */,
+				33C0B2A120512ECA006376A9 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "TestHarness";
+			productName = "TestHarness";
+			productReference = 33C0B28520512E17006376A9 /* TestHarness.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		33C0B27D20512E17006376A9 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0910;
+				ORGANIZATIONNAME = "Digidem";
+				TargetAttributes = {
+					33C0B28420512E17006376A9 = {
+						CreatedOnToolsVersion = 9.1;
+						ProvisioningStyle = Automatic;
+					};
+				};
+			};
+			buildConfigurationList = 33C0B28020512E17006376A9 /* Build configuration list for PBXProject "TestHarness" */;
+			compatibilityVersion = "Xcode 8.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 33C0B27C20512E17006376A9;
+			productRefGroup = 33C0B28620512E17006376A9 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				33C0B28420512E17006376A9 /* TestHarness */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		33C0B28320512E17006376A9 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				33C0B29520512E17006376A9 /* LaunchScreen.storyboard in Resources */,
+				33C0B2A3205131E8006376A9 /* nodejs-project in Resources */,
+				33C0B29220512E17006376A9 /* Assets.xcassets in Resources */,
+				33C0B29020512E17006376A9 /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		33C0B28120512E17006376A9 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				33C0B28D20512E17006376A9 /* ViewController.m in Sources */,
+				33C0B29820512E17006376A9 /* main.m in Sources */,
+				33C0B28A20512E17006376A9 /* AppDelegate.m in Sources */,
+				33C0B2A62051331A006376A9 /* NodeRunner.mm in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		33C0B28E20512E17006376A9 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				33C0B28F20512E17006376A9 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		33C0B29320512E17006376A9 /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				33C0B29420512E17006376A9 /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		33C0B29920512E17006376A9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_BITCODE = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		33C0B29A20512E17006376A9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_BITCODE = NO;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		33C0B29C20512E17006376A9 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/NodeMobile",
+				);
+				INFOPLIST_FILE = "TestHarness/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.digidem.nodejstest";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		33C0B29D20512E17006376A9 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/NodeMobile",
+				);
+				INFOPLIST_FILE = "TestHarness/Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.digidem.nodejstest";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		33C0B28020512E17006376A9 /* Build configuration list for PBXProject "TestHarness" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				33C0B29920512E17006376A9 /* Debug */,
+				33C0B29A20512E17006376A9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		33C0B29B20512E17006376A9 /* Build configuration list for PBXNativeTarget "TestHarness" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				33C0B29C20512E17006376A9 /* Debug */,
+				33C0B29D20512E17006376A9 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 33C0B27D20512E17006376A9 /* Project object */;
+}

--- a/test-harness/ios/TestHarness.xcodeproj/xcshareddata/xcschemes/TestHarness.xcscheme
+++ b/test-harness/ios/TestHarness.xcodeproj/xcshareddata/xcschemes/TestHarness.xcscheme
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1500"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "33C0B28420512E17006376A9"
+               BuildableName = "TestHarness.app"
+               BlueprintName = "TestHarness"
+               ReferencedContainer = "container:TestHarness.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "33C0B28420512E17006376A9"
+            BuildableName = "TestHarness.app"
+            BlueprintName = "TestHarness"
+            ReferencedContainer = "container:TestHarness.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "33C0B28420512E17006376A9"
+            BuildableName = "TestHarness.app"
+            BlueprintName = "TestHarness"
+            ReferencedContainer = "container:TestHarness.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/test-harness/ios/TestHarness/AppDelegate.h
+++ b/test-harness/ios/TestHarness/AppDelegate.h
@@ -1,0 +1,5 @@
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+@property (strong, nonatomic) UIWindow *window;
+@end

--- a/test-harness/ios/TestHarness/AppDelegate.m
+++ b/test-harness/ios/TestHarness/AppDelegate.m
@@ -1,0 +1,37 @@
+#import "AppDelegate.h"
+#import "NodeRunner.h"
+#include <stdio.h>
+#include <stdlib.h>
+
+@interface AppDelegate ()
+@end
+
+@implementation AppDelegate
+
+- (void)startNode {
+    NSString* srcPath = [[NSBundle mainBundle] pathForResource:@"nodejs-project/main.js" ofType:@""];
+    NSArray* nodeArguments = @[ @"node", srcPath ];
+    int rc = [NodeRunner startEngineWithArguments:nodeArguments];
+    // Emit the exit sentinel for the CI workflow to grep.
+    // `simctl launch --console-pty` streams the app's stdout to the runner.
+    fprintf(stdout, "__NODE_EXIT__:%d\n", rc);
+    fflush(stdout);
+    // Terminate the simulator app so simctl's --console-pty attach returns.
+    exit(rc);
+}
+
+- (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions {
+    // Force stdout/stderr line-buffered so prints land in the pty promptly.
+    setvbuf(stdout, NULL, _IOLBF, 0);
+    setvbuf(stderr, NULL, _IOLBF, 0);
+
+    NSThread* nodejsThread = [[NSThread alloc]
+        initWithTarget:self
+        selector:@selector(startNode)
+        object:nil];
+    [nodejsThread setStackSize:2 * 1024 * 1024];
+    [nodejsThread start];
+    return YES;
+}
+
+@end

--- a/test-harness/ios/TestHarness/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/test-harness/ios/TestHarness/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,98 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/test-harness/ios/TestHarness/Base.lproj/LaunchScreen.storyboard
+++ b/test-harness/ios/TestHarness/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" systemVersion="17A277" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/test-harness/ios/TestHarness/Base.lproj/Main.storyboard
+++ b/test-harness/ios/TestHarness/Base.lproj/Main.storyboard
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13196" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" editable="NO" text="Press button above to call process.versions()" textAlignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="jiE-h6-7BZ">
+                                <rect key="frame" x="0.0" y="60" width="375" height="607"/>
+                                <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
+                                <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
+                            </textView>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zbC-aW-1wJ">
+                                <rect key="frame" x="115" y="30" width="145" height="30"/>
+                                <state key="normal" title="Call process.versions"/>
+                                <connections>
+                                    <action selector="myButtonAction:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ItD-Eu-UAI"/>
+                                </connections>
+                            </button>
+                        </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="jiE-h6-7BZ" firstAttribute="height" secondItem="6Tk-OE-BBY" secondAttribute="height" constant="-40" id="1mf-Bh-SDX"/>
+                            <constraint firstItem="jiE-h6-7BZ" firstAttribute="width" secondItem="6Tk-OE-BBY" secondAttribute="width" id="2UH-83-n4i"/>
+                            <constraint firstItem="zbC-aW-1wJ" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="OTm-sZ-6cs"/>
+                            <constraint firstItem="jiE-h6-7BZ" firstAttribute="top" secondItem="zbC-aW-1wJ" secondAttribute="bottom" id="QbE-Vu-O3I"/>
+                            <constraint firstItem="jiE-h6-7BZ" firstAttribute="centerX" secondItem="6Tk-OE-BBY" secondAttribute="centerX" id="rI0-bO-Q9g"/>
+                            <constraint firstItem="zbC-aW-1wJ" firstAttribute="top" secondItem="6Tk-OE-BBY" secondAttribute="top" constant="10" id="wgq-TH-NhE"/>
+                        </constraints>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                    <connections>
+                        <outlet property="myButton" destination="zbC-aW-1wJ" id="MAq-0N-Z5n"/>
+                        <outlet property="myTextView" destination="jiE-h6-7BZ" id="6WK-jx-3E3"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="117.59999999999999" y="118.29085457271366"/>
+        </scene>
+    </scenes>
+</document>

--- a/test-harness/ios/TestHarness/Info.plist
+++ b/test-harness/ios/TestHarness/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+	</array>
+</dict>
+</plist>

--- a/test-harness/ios/TestHarness/NodeRunner.h
+++ b/test-harness/ios/TestHarness/NodeRunner.h
@@ -1,0 +1,9 @@
+#ifndef NodeRunner_h
+#define NodeRunner_h
+#import <Foundation/Foundation.h>
+
+@interface NodeRunner : NSObject {}
++ (int) startEngineWithArguments:(NSArray*)arguments;
+@end
+
+#endif

--- a/test-harness/ios/TestHarness/NodeRunner.mm
+++ b/test-harness/ios/TestHarness/NodeRunner.mm
@@ -1,0 +1,33 @@
+#include "NodeRunner.h"
+#include <NodeMobile/NodeMobile.h>
+#include <string>
+
+@implementation NodeRunner
+
+// libuv requires all argv strings to live in one contiguous allocation.
++ (int) startEngineWithArguments:(NSArray*)arguments
+{
+    int c_arguments_size = 0;
+    for (id argElement in arguments) {
+        c_arguments_size += strlen([argElement UTF8String]);
+        c_arguments_size++;
+    }
+
+    char* args_buffer = (char*)calloc(c_arguments_size, sizeof(char));
+    char* argv[[arguments count]];
+    char* current_args_position = args_buffer;
+    int argument_count = 0;
+
+    for (id argElement in arguments) {
+        const char* current_argument = [argElement UTF8String];
+        strncpy(current_args_position, current_argument, strlen(current_argument));
+        argv[argument_count] = current_args_position;
+        argument_count++;
+        current_args_position += strlen(current_args_position) + 1;
+    }
+
+    int rc = node_start(argument_count, argv);
+    free(args_buffer);
+    return rc;
+}
+@end

--- a/test-harness/ios/TestHarness/ViewController.h
+++ b/test-harness/ios/TestHarness/ViewController.h
@@ -1,0 +1,11 @@
+#import <UIKit/UIKit.h>
+
+// The pbxproj still ships a Main.storyboard with IBOutlet/IBAction bindings
+// inherited from the nodejs-mobile-samples original. We don't use the UI —
+// the app exits as soon as node returns — but the storyboard will KVC-crash
+// on launch if these properties/selectors aren't declared here.
+@interface ViewController : UIViewController
+@property (weak, nonatomic) IBOutlet UIButton *myButton;
+@property (weak, nonatomic) IBOutlet UITextView *myTextView;
+- (IBAction)myButtonAction:(id)sender;
+@end

--- a/test-harness/ios/TestHarness/ViewController.m
+++ b/test-harness/ios/TestHarness/ViewController.m
@@ -1,0 +1,13 @@
+#import "ViewController.h"
+
+@implementation ViewController
+
+- (void)viewDidLoad {
+    [super viewDidLoad];
+}
+
+// Declared only so Main.storyboard's button connection doesn't crash.
+- (IBAction)myButtonAction:(id)sender {
+}
+
+@end

--- a/test-harness/ios/TestHarness/main.m
+++ b/test-harness/ios/TestHarness/main.m
@@ -1,0 +1,16 @@
+//
+//  main.m
+//  native-xcode-node-folder
+//
+//  Created by Jaime Bernardo on 08/03/2018.
+//  Copyright © 2018 Janea Systems. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+#import "AppDelegate.h"
+
+int main(int argc, char * argv[]) {
+    @autoreleasepool {
+        return UIApplicationMain(argc, argv, nil, NSStringFromClass([AppDelegate class]));
+    }
+}


### PR DESCRIPTION
Adds test-android.yml and test-ios.yml: build a minimal native shell app, install and launch it on an emulator/simulator, and stream TAP output back to the workflow log. A `__NODE_EXIT__:<code>` sentinel (emitted from a `process.on('exit')` handler since `process.exit()` bypasses the native post-`node_start` path) drives pass/fail. An auto-generated `require('<module>')` smoke test runs when no test_script is supplied, so callers can validate a prebuild loads without writing any JS.

Shared logic (download artifact, npm install module, place .node under prebuilds/<target>/, wire up main.js) lives in a composite action at .github/actions/assemble-test-project/.

test.yml is a workflow_dispatch wrapper that chains prebuild -> test for one or both platforms so the pipeline can be run from the Actions tab without a caller repo.