### PR TITLE
Overlay upstream test/ for module tests; version-pinned patches

### DIFF
--- a/.github/actions/assemble-test-project/action.yml
+++ b/.github/actions/assemble-test-project/action.yml
@@ -7,7 +7,8 @@ description: |
 
   Three test-runner modes (selected by `test_runner`):
   - 'smoke'  (default): generated test that just `require()`s the module.
-  - 'module': runs the module's own `test/*.js` via brittle.
+  - 'module': runs the module's own `test/*.js` (test folder + devDeps
+              pulled from the upstream repo + tarball's package.json).
   - 'custom': copies the caller's `test_script` in as test.js.
 
   Requires `node`/`npm` on PATH — add an `actions/setup-node` step before
@@ -40,7 +41,10 @@ inputs:
     description: |
       One of 'smoke' (default), 'module', or 'custom'.
       - 'smoke':  auto-generated test that just require()s the module.
-      - 'module': runs the module's own test/*.js (requires brittle).
+      - 'module': runs the module's own test/*.js; devDeps installed
+                  from the tarball's package.json so any test runner
+                  the module uses (brittle / tape / tap / ...) is
+                  available at require() time.
       - 'custom': uses the file pointed to by `test_script`.
     required: false
     default: "smoke"
@@ -110,7 +114,6 @@ runs:
         MODULE_VERSION: ${{ steps.spec.outputs.module_version }}
         TARGET: ${{ inputs.target }}
         NODEDIR: ${{ inputs.nodejs_project_dir }}
-        TEST_RUNNER: ${{ inputs.test_runner }}
       run: |
         set -euo pipefail
         mkdir -p "$NODEDIR"
@@ -119,12 +122,6 @@ runs:
           npm init -y >/dev/null
           npm install --ignore-scripts --no-audit --no-fund \
             "${MODULE_NAME}@${MODULE_VERSION}"
-          # The module's own test files are in the npm tarball but brittle
-          # (a devDep) isn't pulled in by `npm install <pkg>`. Install it
-          # alongside when we're going to run the module's tests.
-          if [ "$TEST_RUNNER" = "module" ]; then
-            npm install --ignore-scripts --no-audit --no-fund --no-save brittle
-          fi
         )
         dst="$NODEDIR/node_modules/${MODULE_NAME}/prebuilds/${TARGET}"
         mkdir -p "$dst"
@@ -132,23 +129,26 @@ runs:
         echo "Prebuild placed under $dst:"
         ls -la "$dst"
 
-    # The `module` test_runner runs the module's own test/*.js via brittle,
+    # The `module` test_runner runs the module's own test/*.js,
     # but npm tarballs almost always exclude test/ (via .npmignore or the
     # package's `files` field). Check out the upstream repo pinned to the
     # SHA/tag resolved from npm metadata and copy its test/ directory into
-    # node_modules/<module>/test/.
-    - name: Checkout upstream test/ folder
+    # node_modules/<module>/test/. Also pull package-lock.json so the
+    # devDep install below can use `npm ci` for deterministic versions.
+    - name: Checkout upstream test/ folder (+ lockfile)
       if: ${{ inputs.test_runner == 'module' && inputs.git_ref != '' }}
       uses: actions/checkout@v6
       with:
         repository: ${{ inputs.git_repo_slug }}
         ref: ${{ inputs.git_ref }}
         path: upstream-src
-        sparse-checkout: test
+        sparse-checkout: |
+          test
+          package-lock.json
         sparse-checkout-cone-mode: false
         fetch-depth: 1
 
-    - name: Overlay upstream test/ into node_modules
+    - name: Overlay upstream test/ (and lockfile) into node_modules
       if: ${{ inputs.test_runner == 'module' && inputs.git_ref != '' }}
       shell: bash
       env:
@@ -156,15 +156,49 @@ runs:
         NODEDIR: ${{ inputs.nodejs_project_dir }}
       run: |
         set -eu
-        src="${GITHUB_WORKSPACE}/upstream-src/test"
-        if [ ! -d "$src" ]; then
-          echo "::error::Upstream checkout has no test/ directory at ${src}"
+        src_test="${GITHUB_WORKSPACE}/upstream-src/test"
+        if [ ! -d "$src_test" ]; then
+          echo "::error::Upstream checkout has no test/ directory at ${src_test}"
           exit 1
         fi
-        dst="${NODEDIR}/node_modules/${MODULE_NAME}/test"
-        rm -rf "$dst"
-        cp -R "$src" "$dst"
-        echo "Overlaid upstream test/ → ${dst}"
+        mod="${NODEDIR}/node_modules/${MODULE_NAME}"
+        rm -rf "$mod/test"
+        cp -R "$src_test" "$mod/test"
+        echo "Overlaid upstream test/ → ${mod}/test"
+
+        # Optional: copy lockfile so the devDep install step can use `npm ci`.
+        # Absent on some older repos / monorepo subdirs; npm install handles
+        # that case.
+        src_lock="${GITHUB_WORKSPACE}/upstream-src/package-lock.json"
+        if [ -f "$src_lock" ]; then
+          cp "$src_lock" "$mod/package-lock.json"
+          echo "Copied upstream package-lock.json → ${mod}/package-lock.json"
+        fi
+
+    # Install the module's devDependencies so its tests can require() whatever
+    # test runner + fixture libs the maintainer uses (brittle / tape / tap /
+    # etc.). Reads the package.json that shipped in the npm tarball, so the
+    # devDep set matches exactly what was published. Uses `npm ci` when the
+    # lockfile is present (deterministic), else falls back to `npm install`.
+    # No brittle-specific shortcut — if this fails, we fail; better to know
+    # than to quietly run against the wrong deps.
+    - name: Install module devDependencies
+      if: ${{ inputs.test_runner == 'module' }}
+      shell: bash
+      env:
+        MODULE_NAME: ${{ steps.spec.outputs.module_name }}
+        NODEDIR: ${{ inputs.nodejs_project_dir }}
+      run: |
+        set -eu
+        mod="${NODEDIR}/node_modules/${MODULE_NAME}"
+        cd "$mod"
+        if [ -f package-lock.json ]; then
+          echo "npm ci in $(pwd) (using upstream package-lock.json)"
+          npm ci --ignore-scripts --no-audit --no-fund
+        else
+          echo "npm install in $(pwd) (no lockfile)"
+          npm install --ignore-scripts --no-audit --no-fund --no-save
+        fi
 
     - name: Place main.js and test.js
       shell: bash
@@ -191,7 +225,7 @@ runs:
             template="$ACTION_PATH/module-tests-runner.js"
             esc=$(printf '%s' "$MODULE_NAME" | sed 's/[\\/&]/\\&/g')
             sed "s/__MODULE_NAME__/$esc/g" "$template" > "$NODEDIR/test.js"
-            echo "test_runner=module: running ${MODULE_NAME}'s own test/*.js via brittle."
+            echo "test_runner=module: running ${MODULE_NAME}'s own test/*.js."
             ;;
           custom)
             if [ -z "$TEST_SCRIPT" ]; then

--- a/.github/actions/assemble-test-project/action.yml
+++ b/.github/actions/assemble-test-project/action.yml
@@ -50,6 +50,22 @@ inputs:
       Only used when test_runner is 'custom'.
     required: false
     default: ""
+  git_repo_slug:
+    description: |
+      'owner/repo' for the module's upstream GitHub repo. Combined with
+      `git_ref`, used to check out the upstream `test/` folder and overlay
+      it into `node_modules/<module>/test/` — the npm tarball typically
+      omits tests via .npmignore. Only consulted when test_runner is
+      'module'.
+    required: false
+    default: ""
+  git_ref:
+    description: |
+      Commit SHA or tag name to check out the upstream repo at. Accepted
+      by `actions/checkout`'s `ref:` input. Only consulted when
+      test_runner is 'module'.
+    required: false
+    default: ""
   nodejs_project_dir:
     description:
       "Absolute or workspace-relative directory to assemble the nodejs-project
@@ -115,6 +131,40 @@ runs:
         cp "$RUNNER_TEMP"/prebuild/*.node "$dst/"
         echo "Prebuild placed under $dst:"
         ls -la "$dst"
+
+    # The `module` test_runner runs the module's own test/*.js via brittle,
+    # but npm tarballs almost always exclude test/ (via .npmignore or the
+    # package's `files` field). Check out the upstream repo pinned to the
+    # SHA/tag resolved from npm metadata and copy its test/ directory into
+    # node_modules/<module>/test/.
+    - name: Checkout upstream test/ folder
+      if: ${{ inputs.test_runner == 'module' && inputs.git_ref != '' }}
+      uses: actions/checkout@v6
+      with:
+        repository: ${{ inputs.git_repo_slug }}
+        ref: ${{ inputs.git_ref }}
+        path: upstream-src
+        sparse-checkout: test
+        sparse-checkout-cone-mode: false
+        fetch-depth: 1
+
+    - name: Overlay upstream test/ into node_modules
+      if: ${{ inputs.test_runner == 'module' && inputs.git_ref != '' }}
+      shell: bash
+      env:
+        MODULE_NAME: ${{ steps.spec.outputs.module_name }}
+        NODEDIR: ${{ inputs.nodejs_project_dir }}
+      run: |
+        set -eu
+        src="${GITHUB_WORKSPACE}/upstream-src/test"
+        if [ ! -d "$src" ]; then
+          echo "::error::Upstream checkout has no test/ directory at ${src}"
+          exit 1
+        fi
+        dst="${NODEDIR}/node_modules/${MODULE_NAME}/test"
+        rm -rf "$dst"
+        cp -R "$src" "$dst"
+        echo "Overlaid upstream test/ → ${dst}"
 
     - name: Place main.js and test.js
       shell: bash

--- a/.github/actions/assemble-test-project/module-tests-runner.js
+++ b/.github/actions/assemble-test-project/module-tests-runner.js
@@ -1,10 +1,16 @@
 // Runs the module-under-test's own test suite inside nodejs-mobile.
 //
-// Holepunch-style modules ship their `test/` folder in the npm tarball and
-// use `brittle` as their test runner (`scripts.test` is typically something
-// like `brittle test/*.js`). Brittle's "CLI" just requires each file; the
-// test() calls register globally and brittle auto-flushes on event-loop
-// drain, printing TAP to stdout. So we do the same here.
+// The module's `test/` folder is populated by the assemble-test-project
+// action (overlaid from the upstream git ref recorded in npm metadata,
+// since tarballs usually exclude test/). DevDeps are installed into
+// `node_modules/<module>/node_modules/` from the tarball's package.json,
+// so whatever runner the module declares — brittle, tape, tap, etc. —
+// is resolvable at require() time.
+//
+// We don't invoke the runner's CLI (there's no shell in an embedded
+// nodejs-mobile runtime). Most JS test runners register tests at import
+// time and auto-flush on event-loop drain, so requiring each test file
+// in order is equivalent to running the module's own `npm test` script.
 //
 // __MODULE_NAME__ is substituted at CI time by the assemble-test-project
 // composite action.
@@ -18,7 +24,7 @@ const testDir = path.join(moduleRoot, 'test')
 if (!fs.existsSync(testDir)) {
   console.log('TAP version 13')
   console.log('1..1')
-  console.log("not ok 1 - __MODULE_NAME__'s npm tarball has no test/ directory")
+  console.log("not ok 1 - __MODULE_NAME__ has no test/ directory (overlay failed?)")
   console.log('  ---')
   console.log('  moduleRoot: ' + JSON.stringify(moduleRoot))
   console.log('  ...')

--- a/.github/actions/prebuild/action.yml
+++ b/.github/actions/prebuild/action.yml
@@ -21,11 +21,17 @@ inputs:
     description: "The version of the module to prebuild"
     required: false
     default: "latest"
-  patch_file:
-    description:
-      "Path to patch file to apply to the module (resolved relative to the
-      caller's workspace)"
+  patches_dir:
+    description: |
+      Directory in the caller's workspace holding patches in the
+      patch-package convention: `<module_name>+<version>.patch`. A file
+      matching the resolved module_version is applied with `patch -p1
+      --forward` after unpack and before install. If sibling patches
+      exist for the same module at other versions but none matches, the
+      step fails loudly (typically a forgotten rename after a version
+      bump).
     required: false
+    default: "patches"
   node_version:
     description: "Node.js version to use"
     required: false
@@ -89,24 +95,47 @@ runs:
         npm pack ${{ inputs.module_name }}@${{ inputs.module_version }} | xargs
         tar -zxvf
 
-    - name: Apply patch if provided
-      if: ${{ inputs.patch_file }}
-      shell: bash
-      run: |
-        if [ -f "${{ inputs.patch_file }}" ]; then
-          echo "Applying patch: ${{ inputs.patch_file }}"
-          cd package
-          patch -p1 < ../${{ inputs.patch_file }}
-        else
-          echo "Patch file not found: ${{ inputs.patch_file }}"
-          exit 1
-        fi
-
     - name: Parse module version
       id: parse-module-version
       shell: bash
       working-directory: ./package
       run: echo version=$(jq -r .version package.json) >> $GITHUB_OUTPUT
+
+    - name: Apply version-pinned patch (if one matches)
+      shell: bash
+      working-directory: ./package
+      env:
+        PATCHES_DIR: ${{ inputs.patches_dir }}
+        MODULE_NAME: ${{ inputs.module_name }}
+        VERSION: ${{ steps.parse-module-version.outputs.version }}
+      run: |
+        set -eu
+        # patch-package convention: patches/<module>+<version>.patch.
+        # The caller's repo is checked out at $GITHUB_WORKSPACE so
+        # PATCHES_DIR resolves there, not inside ./package.
+        patches_root="${GITHUB_WORKSPACE}/${PATCHES_DIR}"
+        match="${patches_root}/${MODULE_NAME}+${VERSION}.patch"
+
+        if [ -f "$match" ]; then
+          echo "Applying patch: ${match}"
+          # --forward + no backup = clean failure on a bad patch instead
+          # of .rej/.orig litter and a false-positive exit 0.
+          patch -p1 --forward --no-backup-if-mismatch < "$match"
+          exit 0
+        fi
+
+        # No exact match — if the caller maintains patches for this
+        # module at other versions, fail loudly. Nearly always a typo
+        # in the filename or a forgotten rename after bumping
+        # module_version.
+        if compgen -G "${patches_root}/${MODULE_NAME}+*.patch" >/dev/null; then
+          echo "::error::No patch matches ${MODULE_NAME}+${VERSION}.patch in ${PATCHES_DIR}/, but other versions exist. Add a patch for ${VERSION} or remove the stale ones."
+          echo "Available patches:"
+          ls "${patches_root}/${MODULE_NAME}"+*.patch
+          exit 1
+        fi
+
+        echo "No patch to apply (no ${MODULE_NAME}+*.patch files in ${PATCHES_DIR}/)."
 
     - name: Install bare-make
       shell: bash

--- a/.github/workflows/prebuild-all.yml
+++ b/.github/workflows/prebuild-all.yml
@@ -23,11 +23,15 @@ on:
         description: "Exact version or dist-tag (e.g. '5.1.0' or 'latest'). Resolved against npm before the matrix runs."
         required: false
         default: "latest"
-      patch_file:
+      patches_dir:
         type: string
-        description: "(Optional) path in the caller repo to a patch file"
+        description: |
+          Directory in the caller repo holding `<module>+<version>.patch`
+          files (patch-package convention). A patch matching the resolved
+          module_version is applied before build; a missing file fails the
+          run if siblings exist for the same module at other versions.
         required: false
-        default: ""
+        default: "patches"
     outputs:
       module_version:
         description: "The exact version resolved and used for all builds"
@@ -38,17 +42,37 @@ on:
           Pass this directly to test-*.yml / release.yml so downstream steps
           stay pinned to exactly what was built.
         value: ${{ inputs.module_name }}@${{ jobs.resolve.outputs.version }}
+      git_repo_slug:
+        description: |
+          'owner/repo' for the module's upstream GitHub repo, derived from
+          the package's `repository.url` metadata. Empty when the upstream
+          isn't on GitHub or `repository.url` is missing. Feeds
+          `actions/checkout` in the test-*.yml workflows so module tests can
+          run against the upstream `test/` folder (usually excluded from the
+          npm tarball).
+        value: ${{ jobs.resolve.outputs.git_repo_slug }}
+      git_ref:
+        description: |
+          Git ref to check out the upstream repo at — a commit SHA from
+          `npm view ... gitHead` when available, else a `v<version>` tag
+          confirmed via the GitHub API, else empty. Both forms are accepted
+          by `actions/checkout`'s `ref:` input. Empty means module tests
+          can't be run (test_runner=module will fail loudly).
+        value: ${{ jobs.resolve.outputs.git_ref }}
 
 jobs:
   resolve:
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.resolve.outputs.version }}
+      git_repo_slug: ${{ steps.resolve.outputs.git_repo_slug }}
+      git_ref: ${{ steps.resolve.outputs.git_ref }}
     steps:
       - id: resolve
         env:
           MODULE_NAME: ${{ inputs.module_name }}
           SPEC: ${{ inputs.module_version }}
+          GH_TOKEN: ${{ github.token }}
         shell: bash
         run: |
           set -eu
@@ -61,6 +85,35 @@ jobs:
           fi
           echo "Resolved ${MODULE_NAME}@${SPEC} -> ${ver}"
           echo "version=${ver}" >> "$GITHUB_OUTPUT"
+
+          # Best-effort resolve upstream git source for test overlay.
+          # Failures here leave outputs empty; test_runner=module handles
+          # that by failing loudly at test time.
+          slug=""
+          ref=""
+          repo_url=$(npm view "${MODULE_NAME}@${ver}" repository.url 2>/dev/null || true)
+          case "$repo_url" in
+            *github.com*)
+              slug=$(printf '%s' "$repo_url" \
+                | sed -E 's#^git\+##; s#\.git$##; s#^git@github\.com:##; s#^ssh://git@github\.com/##; s#^https?://github\.com/##')
+              ;;
+          esac
+
+          if [ -n "$slug" ]; then
+            git_head=$(npm view "${MODULE_NAME}@${ver}" gitHead 2>/dev/null || true)
+            if printf '%s' "$git_head" | grep -qE '^[0-9a-f]{40}$'; then
+              # gitHead may point at a commit not reachable from any branch
+              # (force-pushed history); actions/checkout still finds it via
+              # the object database when passed a bare SHA.
+              ref="$git_head"
+            elif gh api "repos/${slug}/git/refs/tags/v${ver}" >/dev/null 2>&1; then
+              ref="v${ver}"
+            fi
+          fi
+
+          echo "Upstream git: slug='${slug}' ref='${ref}'"
+          echo "git_repo_slug=${slug}" >> "$GITHUB_OUTPUT"
+          echo "git_ref=${ref}"        >> "$GITHUB_OUTPUT"
 
   build:
     needs: resolve
@@ -86,7 +139,7 @@ jobs:
     timeout-minutes: 20
     name: ${{ inputs.module_name }} (${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.simulator && '-simulator' || '' }})
     steps:
-      # Caller's repo — needed so `patch_file` (a caller-relative path)
+      # Caller's repo — needed so `patches_dir` (a caller-relative path)
       # resolves against the workspace root.
       - uses: actions/checkout@v6
 
@@ -97,4 +150,4 @@ jobs:
           arch: ${{ matrix.arch }}
           simulator: ${{ matrix.simulator || false }}
           module_version: ${{ needs.resolve.outputs.version }}
-          patch_file: ${{ inputs.patch_file }}
+          patches_dir: ${{ inputs.patches_dir }}

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -34,10 +34,14 @@ on:
         description: "Exact version or dist-tag (e.g. '5.1.0' or 'latest'). Resolved by `npm pack`."
         required: false
         default: "latest"
-      patch_file:
+      patches_dir:
         type: string
-        description: "Path to patch file to apply to the module (optional)"
+        description: |
+          Directory in the caller repo holding `<module>+<version>.patch`
+          files (patch-package convention). A patch matching the resolved
+          module_version is applied before build.
         required: false
+        default: "patches"
   workflow_call:
     inputs:
       module_name:
@@ -64,10 +68,14 @@ on:
         description: "Exact version or dist-tag (e.g. '5.1.0' or 'latest'). Resolved by `npm pack`."
         required: false
         default: "latest"
-      patch_file:
+      patches_dir:
         type: string
-        description: "Path to patch file to apply to the module (optional)"
+        description: |
+          Directory in the caller repo holding `<module>+<version>.patch`
+          files (patch-package convention). A patch matching the resolved
+          module_version is applied before build.
         required: false
+        default: "patches"
     outputs:
       module_version:
         description: "The resolved version of the module"
@@ -84,7 +92,7 @@ jobs:
     outputs:
       module_version: ${{ steps.prebuild.outputs.module_version }}
     steps:
-      # Caller's repo — needed so `patch_file` (a caller-relative path)
+      # Caller's repo — needed so `patches_dir` (a caller-relative path)
       # resolves against the workspace root.
       - uses: actions/checkout@v6
 
@@ -96,4 +104,4 @@ jobs:
           arch: ${{ inputs.arch }}
           simulator: ${{ inputs.simulator }}
           module_version: ${{ inputs.module_version }}
-          patch_file: ${{ inputs.patch_file }}
+          patches_dir: ${{ inputs.patches_dir }}

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -59,6 +59,23 @@ on:
         description: "Ref of digidem/nodejs-mobile-bare-prebuilds to pull the harness from"
         required: false
         default: "main"
+      git_repo_slug:
+        type: string
+        description: |
+          'owner/repo' for the module's upstream GitHub repo. Output by
+          prebuild-all.yml. Used with `git_ref` to check out the module's
+          `test/` folder for `test_runner: module` (the npm tarball
+          typically omits tests).
+        required: false
+        default: ""
+      git_ref:
+        type: string
+        description: |
+          Git ref (commit SHA or tag name) to check out the upstream repo
+          at. Output by prebuild-all.yml. Accepted by `actions/checkout`'s
+          `ref:` input. Only used when `test_runner` is 'module'.
+        required: false
+        default: ""
 
 jobs:
   test:
@@ -140,6 +157,8 @@ jobs:
           artifact_name: ${{ inputs.artifact_name }}
           test_runner: ${{ inputs.test_runner }}
           test_script: ${{ inputs.test_script }}
+          git_repo_slug: ${{ inputs.git_repo_slug }}
+          git_ref: ${{ inputs.git_ref }}
           nodejs_project_dir: .nodejs-mobile-bare-prebuilds/test-harness/android/app/src/main/assets/nodejs-project
 
       - uses: gradle/actions/setup-gradle@50e97c2cd7a37755bbfafc9c5b7cafaece252f6e # v6.1.0

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -59,6 +59,23 @@ on:
         description: "Ref of digidem/nodejs-mobile-bare-prebuilds to pull the harness from"
         required: false
         default: "main"
+      git_repo_slug:
+        type: string
+        description: |
+          'owner/repo' for the module's upstream GitHub repo. Output by
+          prebuild-all.yml. Used with `git_ref` to check out the module's
+          `test/` folder for `test_runner: module` (the npm tarball
+          typically omits tests).
+        required: false
+        default: ""
+      git_ref:
+        type: string
+        description: |
+          Git ref (commit SHA or tag name) to check out the upstream repo
+          at. Output by prebuild-all.yml. Accepted by `actions/checkout`'s
+          `ref:` input. Only used when `test_runner` is 'module'.
+        required: false
+        default: ""
 
 jobs:
   test:
@@ -117,6 +134,8 @@ jobs:
           artifact_name: ${{ inputs.artifact_name }}
           test_runner: ${{ inputs.test_runner }}
           test_script: ${{ inputs.test_script }}
+          git_repo_slug: ${{ inputs.git_repo_slug }}
+          git_ref: ${{ inputs.git_ref }}
           nodejs_project_dir: .nodejs-mobile-bare-prebuilds/test-harness/ios/nodejs-project
 
       - name: Build TestHarness.app

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,11 @@ on:
         description: "(Optional) path to a test script in this repo; blank uses the default require() smoke test"
         required: false
         default: ""
-      patch_file:
+      patches_dir:
         type: string
-        description: "(Optional) path to a patch file to apply to the module before building"
+        description: "(Optional) directory with <module>+<version>.patch files"
         required: false
-        default: ""
+        default: "patches"
 
 jobs:
   build-android:
@@ -50,7 +50,7 @@ jobs:
       platform: android
       arch: x64
       module_version: ${{ inputs.module_version }}
-      patch_file: ${{ inputs.patch_file }}
+      patches_dir: ${{ inputs.patches_dir }}
 
   test-android:
     if: ${{ inputs.platforms == 'both' || inputs.platforms == 'android' }}
@@ -70,7 +70,7 @@ jobs:
       arch: arm64
       simulator: true
       module_version: ${{ inputs.module_version }}
-      patch_file: ${{ inputs.patch_file }}
+      patches_dir: ${{ inputs.patches_dir }}
 
   test-ios:
     if: ${{ inputs.platforms == 'both' || inputs.platforms == 'ios' }}

--- a/README.md
+++ b/README.md
@@ -7,8 +7,13 @@ by the Holepunch team. These modules are built using
 ## Table of Contents
 
 - [Introduction](#introduction)
-- [Getting Started](#getting-started)
 - [Usage](#usage)
+  - [Inputs](#inputs)
+  - [Outputs](#outputs)
+  - [Manual dispatch](#manual-dispatch)
+- [Testing prebuilds on an emulator / simulator](#testing-prebuilds-on-an-emulator--simulator)
+  - [Running the module's own test suite](#running-the-modules-own-test-suite)
+- [Patching the module before build](#patching-the-module-before-build)
 - [Contributing](#contributing)
 - [License](#license)
 
@@ -19,152 +24,162 @@ tools to streamline the process of building native modules for Node.js mobile
 applications. These workflows are designed to be used with the `bare-make` build
 system.
 
+The build input is always the **npm tarball** (`npm pack <module>@<version>`),
+so the published prebuild corresponds exactly to what users get from
+`npm install`. The test input is the **upstream git repo** at the commit the
+tarball was published from — needed because the `test/` folder is almost always
+excluded from npm tarballs.
+
 ## Usage
 
-The prebuild step is published as a composite action. Call it from a job in your
-own repository, typically inside a matrix so each architecture builds in
-parallel. The `release.yml` reusable workflow collects the uploaded artifacts
-and creates a GitHub Release.
+The most common entry point is `prebuild-all.yml`, which builds the standard
+target set (three Android ABIs + iOS device + two iOS simulator slices),
+optionally runs the module's own test suite on an emulator/simulator, and
+publishes a GitHub Release with the artifacts.
 
 ```yaml
-name: Generate prebuilds
+name: Build, test, and release prebuilds
 
 on:
   workflow_dispatch:
     inputs:
       module_version:
-        description: "Module version"
-        required: true
+        description: "Exact version or dist-tag"
+        required: false
         default: "latest"
         type: string
-      publish_release:
-        description: "Publish release"
-        required: false
-        default: true
-        type: boolean
 
 jobs:
   build:
-    strategy:
-      matrix:
-        platform: [android]
-        arch: [arm64, x64, arm]
-    runs-on: ubuntu-22.04
-    outputs:
-      module_version: ${{ steps.prebuild.outputs.module_version }}
-    steps:
-      - uses: actions/checkout@v6
-      - id: prebuild
-        uses: digidem/nodejs-mobile-bare-prebuilds/.github/actions/prebuild@main
-        with:
-          module_name: quickbit-native
-          module_version: ${{ inputs.module_version }}
-          platform: ${{ matrix.platform }}
-          arch: ${{ matrix.arch }}
-          patch_file: CMakeLists.txt.patch
+    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/prebuild-all.yml@v2
+    with:
+      module_name: sodium-native
+      module_version: ${{ inputs.module_version }}
+
+  test-android:
+    needs: build
+    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/test-android.yml@v2
+    with:
+      module_spec: ${{ needs.build.outputs.module_spec }}
+      test_runner: module
+      git_repo_slug: ${{ needs.build.outputs.git_repo_slug }}
+      git_ref: ${{ needs.build.outputs.git_ref }}
+
+  test-ios:
+    needs: build
+    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/test-ios.yml@v2
+    with:
+      module_spec: ${{ needs.build.outputs.module_spec }}
+      test_runner: module
+      git_repo_slug: ${{ needs.build.outputs.git_repo_slug }}
+      git_ref: ${{ needs.build.outputs.git_ref }}
 
   release:
-    if: ${{ inputs.publish_release }}
-    needs: build
-    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/release.yml@main
+    needs: [ build, test-android, test-ios ]
+    permissions:
+      contents: write
+    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/release.yml@v2
     with:
-      module_version: ${{ needs.build.outputs.module_version }}
+      module_spec: ${{ needs.build.outputs.module_spec }}
 ```
 
 ### Inputs
 
-| Input            | Required | Default   | Description                                                          |
-| ---------------- | -------- | --------- | -------------------------------------------------------------------- |
-| `module_name`    | yes      | —         | Name of the npm module to prebuild                                   |
-| `platform`       | yes      | `android` | Target platform                                                      |
-| `arch`           | yes      | `arm64`   | Target architecture (`arm64`, `x64`, `arm`)                          |
-| `module_version` | no       | `latest`  | Version of the module to pull from npm                               |
-| `patch_file`     | no       | —         | Path to a patch file in the caller's workspace to apply to `package` |
-| `node_version`   | no       | `18`      | Node.js version used to run `bare-make`                              |
+**`prebuild-all.yml` / `prebuild.yml`**
+
+| Input            | Required | Default    | Description                                                                       |
+| ---------------- | -------- | ---------- | --------------------------------------------------------------------------------- |
+| `module_name`    | yes      | —          | npm module to build                                                               |
+| `module_version` | no       | `latest`   | Exact version or dist-tag. Resolved against npm before the matrix runs.           |
+| `patches_dir`    | no       | `patches`  | Directory in the caller repo holding `<module>+<version>.patch` files (see below) |
 
 ### Outputs
 
-| Output           | Description                                   |
-| ---------------- | --------------------------------------------- |
-| `module_version` | The resolved version read from `package.json` |
+**`prebuild-all.yml`**
+
+| Output           | Description                                                                                   |
+| ---------------- | --------------------------------------------------------------------------------------------- |
+| `module_version` | The exact version resolved and used for all builds                                            |
+| `module_spec`    | `<module>@<version>` — pass to `test-*.yml` / `release.yml`                                   |
+| `git_repo_slug`  | `owner/repo` of the upstream GitHub repo, or empty if not on GitHub / no `repository.url`    |
+| `git_ref`        | Commit SHA (from `gitHead`) or `v<version>` tag, or empty if neither resolves                |
 
 ### Manual dispatch
 
-The `.github/workflows/prebuild.yml` workflow in this repository is kept as a
-thin wrapper around the composite action so the build can be triggered manually
-from the Actions tab for debugging.
+`prebuild.yml` is a thin wrapper around the composite action for single-target
+builds, triggerable from the Actions tab for debugging. `test.yml` chains
+`prebuild → test-*` for end-to-end debugging on a branch.
 
 ## Testing prebuilds on an emulator / simulator
 
 Two reusable workflows run the built `.node` file inside nodejs-mobile on a
 real emulator / simulator to catch runtime issues the prebuild step cannot
 (wrong page size, missing symbols, `require-addon` not finding the binary,
-etc.).
+etc.). The workflow bundles a `test.js` and the installed module into a
+minimal native app, installs it on an emulator / simulator, streams the app's
+stdout into the workflow log, and passes/fails on the Node exit code.
 
-The caller's repo provides a `test.js` that outputs TAP; the workflow bundles
-it with the artifact and the module-under-test into a minimal native app,
-installs it on an emulator / simulator, streams the app's stdout into the
-workflow log, and passes/fails on the Node exit code.
+Three `test_runner` modes, selected per test workflow:
 
-If `test_script` is omitted, a minimal smoke test is generated that just does
-`require('<module_name>')` and exits non-zero if it throws — enough to catch
-linker / load-time breakage without the caller needing to write any JS.
+- **`smoke`** (default): generated test that just `require()`s the module.
+  Enough to catch linker / load-time breakage without caller JS.
+- **`module`**: runs the module's own `test/*.js` via `brittle`. See below.
+- **`custom`**: uses the file at `test_script` (caller-repo path).
 
-```yaml
-jobs:
-  build-android-x64:
-    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/prebuild.yml@main
-    with:
-      module_name: sodium-native
-      platform: android
-      arch: x64
+### Running the module's own test suite
 
-  test-android:
-    needs: build-android-x64
-    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/test-android.yml@main
-    with:
-      module_name: sodium-native
-      module_version: ${{ needs.build-android-x64.outputs.module_version }}
-      artifact_name: sodium-native-${{ needs.build-android-x64.outputs.module_version }}-android-x64
-      target: android-x64    # the prebuilds/<dir>/ to install into
-      # test_script: test.js   # omit to get a default require() smoke test   # caller-repo path; outputs TAP on stdout
+The `test/` folder is usually excluded from npm tarballs (via `.npmignore` or
+the package's `files` field), so the test workflows check out the upstream
+GitHub repo separately and overlay its `test/` into
+`node_modules/<module>/test/` before running.
 
-  build-ios-sim-arm64:
-    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/prebuild.yml@main
-    with:
-      module_name: sodium-native
-      platform: ios
-      arch: arm64
-      simulator: true
+The git ref is resolved in `prebuild-all.yml`'s `resolve` job:
 
-  test-ios:
-    needs: build-ios-sim-arm64
-    uses: digidem/nodejs-mobile-bare-prebuilds/.github/workflows/test-ios.yml@main
-    with:
-      module_name: sodium-native
-      module_version: ${{ needs.build-ios-sim-arm64.outputs.module_version }}
-      artifact_name: sodium-native-${{ needs.build-ios-sim-arm64.outputs.module_version }}-ios-arm64-simulator
-      # At runtime on the simulator nodejs-mobile reports platform+arch as
-      # 'ios-arm64' (no -simulator suffix), so the .node file is installed
-      # under prebuilds/ios-arm64/. Leave `target` at its default.
-      # test_script: test.js   # omit to get a default require() smoke test
+1. **`gitHead` from npm metadata** — recorded by `npm publish` and usually
+   reliable for modern publishes. This is a commit SHA; `actions/checkout`
+   accepts bare SHAs even when the commit isn't reachable from a branch
+   (e.g. after a force-push).
+2. **`v<version>` tag** — checked via the GitHub API (authenticated with
+   `GITHUB_TOKEN`). Fallback for older tarballs with missing `gitHead`.
+3. **Empty** — no git source available. `test_runner: module` will fail
+   loudly at test time; use `smoke` instead.
+
+Pass both `git_repo_slug` and `git_ref` from `prebuild-all.yml`'s outputs into
+the test workflows when using `test_runner: module`. Non-GitHub upstreams are
+not supported in v2.
+
+**Note:** the build always uses the npm tarball as its source. The git
+checkout is only used to populate the `test/` folder for the `module` test
+runner.
+
+## Patching the module before build
+
+Some modules need small patches to build for nodejs-mobile — e.g. fixing an
+include path in `CMakeLists.txt`. Patches use the
+[patch-package](https://github.com/ds300/patch-package) filename convention:
+
+```
+<caller-repo>/
+└── patches/
+    ├── quickbit-native+2.4.1.patch
+    └── quickbit-native+2.4.2.patch
 ```
 
-The native shells used by the test workflows live under
-[test-harness/android/](test-harness/android/) and
-[test-harness/ios/](test-harness/ios/). They each load the module-under-test,
-run `test.js` as the main script, pipe stdout/stderr back to the workflow log
-(logcat on Android, `simctl launch --console-pty` on iOS), and emit a
-`__NODE_EXIT__:<code>` sentinel the workflow parses to set pass/fail.
+The prebuild step picks `patches/<module_name>+<resolved_version>.patch` and
+applies it with `patch -p1 --forward --no-backup-if-mismatch` after `npm pack`
+unpack and before `npm install`.
 
-### Manual dispatch
+**Failure modes:**
+- Patch applies cleanly → build proceeds.
+- No `<module>+*.patch` files exist → no-op, build proceeds.
+- A matching file is missing but siblings for other versions exist → **fail
+  loudly**. This catches the usual error of forgetting to rename the patch
+  after bumping `module_version`.
+- Patch applies but with fuzz/rejects → **fail loudly** (`--forward`
+  suppresses the interactive prompt and surfaces rejects as a non-zero exit).
 
-The [.github/workflows/test.yml](.github/workflows/test.yml) workflow chains
-`prebuild.yml` → `test-*.yml` behind a `workflow_dispatch` trigger so the whole
-pipeline can be exercised from the Actions tab without a caller repo. The
-harness is checked out at the same commit as the dispatch run, so in-flight
-changes on a branch are tested as-is. Platforms can be selected individually
-or together.
+To use a different directory name, pass `patches_dir:` to
+`prebuild-all.yml` / `prebuild.yml`.
 
 ## Contributing
 


### PR DESCRIPTION
Test workflows now overlay the upstream `test/` folder (sparse-checkout at the `gitHead` SHA from npm metadata, or `v<version>` tag fallback) into `node_modules/<module>/`, then `npm ci` / `npm install` in the module dir so the module's devDeps are resolvable at require() time. Works with any test runner the module uses.

Patches move to the patch-package convention (`patches/<module>+<version>.patch`) with exact-version lookup. Applied with `patch -p1 --forward --no-backup-if-mismatch`; mismatches and missing-patch-when-siblings-exist both fail loudly.

## Breaking changes

- `patch_file` input removed. Use `patches/<module>+<version>.patch` in the caller repo (override the dir with the new `patches_dir` input).
- `prebuild-all.yml` emits new `git_repo_slug` and `git_ref` outputs; `test-android.yml` / `test-ios.yml` accept matching inputs — required in practice for `test_runner: module`.
- Upstream repos must be on GitHub for `test_runner: module`.

Caller migrations: digidem/sodium-native-nodejs-mobile#2, digidem/quickbit-native-nodejs-mobile#2.

https://claude.ai/code/session_01WtF58dpHdYqs2dMythfwz9