### PR TITLE
fix(android): target API 24 so prebuilds load on Android < 9

### DIFF
--- a/.github/actions/prebuild/action.yml
+++ b/.github/actions/prebuild/action.yml
@@ -163,6 +163,17 @@ runs:
         esac
         case "${{ inputs.platform }}" in
           android)
+            # bare-make's Android toolchain (holepunchto/cmake-toolchains)
+            # defaults to ANDROID_PLATFORM=android-29. Recent NDKs emit RELR
+            # packed relocations by default when targeting API >= 28, and
+            # Android < 9 cannot load those: the older dynamic linker logs
+            # "unused DT entry" for the unknown DT_ANDROID_RELR tags
+            # (0x6fffe000/1/3), skips the relocations, and the library
+            # SIGSEGVs on first use. Pin the target API to nodejs-mobile's
+            # support floor (Android 7.0, API 24) so relative relocations
+            # stay in plain .rela.dyn, loadable on every supported device.
+            extra_args+=(-D ANDROID_PLATFORM=android-24)
+
             # bare-make's Android toolchain leaves ANDROID_STL=none, so the
             # NDK's clang adds -nostdinc++ and no C++ stdlib headers are in
             # scope. Modules that include any C++ stdlib header (e.g.

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -96,7 +96,7 @@ jobs:
       # resolves against the workspace root.
       - uses: actions/checkout@v6
 
-      - uses: digidem/nodejs-mobile-bare-prebuilds/.github/actions/prebuild@fix/android-platform-24
+      - uses: digidem/nodejs-mobile-bare-prebuilds/.github/actions/prebuild@main
         id: prebuild
         with:
           module_name: ${{ inputs.module_name }}

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -96,7 +96,7 @@ jobs:
       # resolves against the workspace root.
       - uses: actions/checkout@v6
 
-      - uses: digidem/nodejs-mobile-bare-prebuilds/.github/actions/prebuild@main
+      - uses: digidem/nodejs-mobile-bare-prebuilds/.github/actions/prebuild@fix/android-platform-24
         id: prebuild
         with:
           module_name: ${{ inputs.module_name }}

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -62,6 +62,16 @@ on:
         description: "Android API level for the emulator"
         required: false
         default: 30
+      floor_api_level:
+        type: number
+        description: |
+          Oldest Android API level the prebuild must load on. Runs the same
+          test on a second, older emulator. Guards against toolchain output
+          that newer devices accept but older linkers can't load — e.g. RELR
+          packed relocations (emitted when ANDROID_PLATFORM >= 28) SIGSEGV
+          on Android < 9. Set equal to `api_level` to skip the second run.
+        required: false
+        default: 27
       harness_ref:
         type: string
         description: "Ref of digidem/nodejs-mobile-bare-prebuilds to pull the harness from"
@@ -89,11 +99,19 @@ jobs:
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        # Test on both the requested API level and the floor API level
+        # (deduped when they're equal).
+        api-level: ${{ fromJSON(inputs.api_level == inputs.floor_api_level && format('[{0}]', inputs.api_level) || format('[{0},{1}]', inputs.floor_api_level, inputs.api_level)) }}
+    name: test (API ${{ matrix.api-level }})
     steps:
-      - name: Map target to emulator arch
+      - name: Map target to emulator arch and image
         id: inputs
         env:
           TARGET: ${{ inputs.target }}
+          API_LEVEL: ${{ matrix.api-level }}
         shell: bash
         run: |
           set -eu
@@ -105,6 +123,12 @@ jobs:
               exit 1
               ;;
           esac
+          # ATD (automated test device) system images only exist for API 30+.
+          if [ "$API_LEVEL" -ge 30 ]; then
+            echo "emulator_target=google_atd" >> "$GITHUB_OUTPUT"
+          else
+            echo "emulator_target=default" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Checkout caller repo
         uses: actions/checkout@v6
@@ -187,14 +211,14 @@ jobs:
           path: |
             ~/.android/avd/*
             ~/.android/adb*
-          key: avd-api${{ inputs.api_level }}-${{ steps.inputs.outputs.emulator_arch }}-v1
+          key: avd-api${{ matrix.api-level }}-${{ steps.inputs.outputs.emulator_arch }}-v1
 
       - name: Generate AVD snapshot
         if: steps.avd-cache.outputs.cache-hit != 'true'
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         with:
-          api-level: ${{ inputs.api_level }}
-          target: google_atd
+          api-level: ${{ matrix.api-level }}
+          target: ${{ steps.inputs.outputs.emulator_target }}
           arch: ${{ steps.inputs.outputs.emulator_arch }}
           force-avd-creation: false
           ram-size: 4096M
@@ -205,8 +229,8 @@ jobs:
       - name: Run test on emulator
         uses: reactivecircus/android-emulator-runner@e89f39f1abbbd05b1113a29cf4db69e7540cae5a # v2.37.0
         with:
-          api-level: ${{ inputs.api_level }}
-          target: google_atd
+          api-level: ${{ matrix.api-level }}
+          target: ${{ steps.inputs.outputs.emulator_target }}
           arch: ${{ steps.inputs.outputs.emulator_arch }}
           force-avd-creation: false
           ram-size: 4096M

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -69,9 +69,10 @@ on:
           test on a second, older emulator. Guards against toolchain output
           that newer devices accept but older linkers can't load — e.g. RELR
           packed relocations (emitted when ANDROID_PLATFORM >= 28) SIGSEGV
-          on Android < 9. Set equal to `api_level` to skip the second run.
+          on Android < 9. Default matches the ANDROID_PLATFORM the prebuild
+          action targets. Set equal to `api_level` to skip the second run.
         required: false
-        default: 27
+        default: 24
       harness_ref:
         type: string
         description: "Ref of digidem/nodejs-mobile-bare-prebuilds to pull the harness from"

--- a/test-harness/android/run-test.sh
+++ b/test-harness/android/run-test.sh
@@ -24,6 +24,11 @@ adb shell am start -W -n "$APP_ID/.TestActivity"
 # notices the pipe has closed when it next tries to write, and no further
 # lines are coming once the app has exited.)
 coproc LOGCAT { adb logcat -v raw -s NODEJS-MOBILE:V; }
+# Snapshot the coproc's PID and read FD: bash UNSETS LOGCAT_PID and
+# LOGCAT[0] as soon as it reaps the terminated coprocess, so reading
+# them later can trip `set -u` (observed when the app exits quickly).
+logcat_pid="${LOGCAT_PID}"
+logcat_fd="${LOGCAT[0]}"
 
 EXIT_CODE=""
 APP_DIED=""
@@ -31,7 +36,7 @@ SECONDS=0
 while (( SECONDS < TIMEOUT_SECONDS )); do
   # Per-read timeout keeps the outer timeout check live even when logcat
   # is silent (app crashed without emitting the sentinel, etc.).
-  if IFS= read -r -u "${LOGCAT[0]}" -t 10 line; then
+  if IFS= read -r -u "$logcat_fd" -t 10 line; then
     printf '%s\n' "$line"
     case "$line" in
       *__NODE_EXIT__:*)
@@ -51,9 +56,9 @@ done
 # Kill the adb logcat client itself, not just the coproc subshell — a
 # surviving client keeps an adb server connection open, which has hung
 # android-emulator-runner's emulator teardown until the job timeout.
-kill "${LOGCAT_PID}" 2>/dev/null || true
+kill "$logcat_pid" 2>/dev/null || true
 pkill -f 'adb logcat' 2>/dev/null || true
-wait "${LOGCAT_PID}" 2>/dev/null || true
+wait "$logcat_pid" 2>/dev/null || true
 
 if [ -n "$APP_DIED" ]; then
   echo "::error::App process died without emitting __NODE_EXIT__ (native crash?). Recent crash log:"

--- a/test-harness/android/run-test.sh
+++ b/test-harness/android/run-test.sh
@@ -8,6 +8,7 @@
 set -euo pipefail
 
 APK="${GITHUB_WORKSPACE}/.nodejs-mobile-bare-prebuilds/test-harness/android/app/build/outputs/apk/debug/app-debug.apk"
+APP_ID=com.digidem.nodejstest
 TIMEOUT_SECONDS=1200
 
 adb wait-for-device shell 'while [[ -z $(getprop sys.boot_completed) ]]; do sleep 1; done'
@@ -16,7 +17,7 @@ adb logcat -c
 
 # Launch the activity. The app pumps node's stdout/stderr to logcat tag
 # NODEJS-MOBILE and emits __NODE_EXIT__:<code> when done.
-adb shell am start -W -n com.digidem.nodejstest/.TestActivity
+adb shell am start -W -n "$APP_ID/.TestActivity"
 
 # Run logcat as a coprocess so we can kill it explicitly once the sentinel
 # is seen. (A plain `adb logcat | awk` pipeline hangs because adb only
@@ -25,6 +26,7 @@ adb shell am start -W -n com.digidem.nodejstest/.TestActivity
 coproc LOGCAT { adb logcat -v raw -s NODEJS-MOBILE:V; }
 
 EXIT_CODE=""
+APP_DIED=""
 SECONDS=0
 while (( SECONDS < TIMEOUT_SECONDS )); do
   # Per-read timeout keeps the outer timeout check live even when logcat
@@ -37,11 +39,27 @@ while (( SECONDS < TIMEOUT_SECONDS )); do
         break
         ;;
     esac
+  elif [ -z "$(adb shell pidof -s "$APP_ID" 2>/dev/null | tr -d '[:space:]')" ]; then
+    # Logcat went quiet AND the app process is gone: it crashed without
+    # emitting the sentinel (e.g. a native SIGSEGV in an addon). Fail
+    # now instead of waiting out the full TIMEOUT_SECONDS.
+    APP_DIED=1
+    break
   fi
 done
 
+# Kill the adb logcat client itself, not just the coproc subshell — a
+# surviving client keeps an adb server connection open, which has hung
+# android-emulator-runner's emulator teardown until the job timeout.
 kill "${LOGCAT_PID}" 2>/dev/null || true
+pkill -f 'adb logcat' 2>/dev/null || true
 wait "${LOGCAT_PID}" 2>/dev/null || true
+
+if [ -n "$APP_DIED" ]; then
+  echo "::error::App process died without emitting __NODE_EXIT__ (native crash?). Recent crash log:"
+  adb logcat -d -t 100 -b crash 2>/dev/null || true
+  exit 1
+fi
 
 if [ -z "$EXIT_CODE" ]; then
   echo "::error::Did not observe __NODE_EXIT__ sentinel within ${TIMEOUT_SECONDS}s"


### PR DESCRIPTION
## Problem

Android prebuilds produced by this pipeline crash with SIGSEGV immediately after `dlopen` on devices running Android 8.1 and below. Surfaced in comapeo-core-react-native e2e tests on a Samsung Galaxy Note 9 (Android 8.1), with this in logcat just before the crash:

```
W/linker: "...libsodium-native__5.1.0.so" unused DT entry: type 0x6fffe000 arg 0xdbf0
W/linker: "...libsodium-native__5.1.0.so" unused DT entry: type 0x6fffe001 arg 0x48
W/linker: "...libsodium-native__5.1.0.so" unused DT entry: type 0x6fffe003 arg 0x8
E/libsigchain: exiting due to SIG_DFL handler for signal 11
```

Those tags are `DT_ANDROID_RELR` / `RELRSZ` / `RELRENT` — RELR packed relocations, which Android's dynamic linker only supports from Android 9 (API 28). Older linkers log "unused DT entry", **silently skip the relocations**, and the library crashes the first time it touches an unrelocated pointer.

## Cause

bare-make's Android toolchain ([holepunchto/cmake-toolchains](https://github.com/holepunchto/cmake-toolchains/blob/main/android-arm64.cmake)) defaults to `ANDROID_PLATFORM=android-29`, and recent NDKs emit RELR by default when the target API is >= 28. Verified with `llvm-readelf -d` that **every** published addon prebuild (sodium-native, better-sqlite3, crc-native, fs-native-extensions, quickbit-native, rabin-native, simdle-native) carries the three `DT_ANDROID_RELR` entries, while nodejs-mobile's own `libnode.so` does not (which is why Node itself boots fine on these devices and the crash lands on the first addon load).

## Fix

Pass `-D ANDROID_PLATFORM=android-24` in the Generate step (the toolchain's `if(NOT DEFINED ...)` guard makes the override clean). API 24 is nodejs-mobile's support floor (Android 7.0) and matches React Native 0.76+/Expo minSdk. Targeting < 28 makes the linker keep relative relocations in plain `.rela.dyn`, loadable on every supported Android version (verified locally with the NDK: an `android-24` target emits no RELR).

## Rollout

Existing release artifacts are all affected — after this merges, each addon repo's prebuilds workflow needs re-dispatching for its pinned versions so the release assets get rebuilt (the reusable workflow references this action `@main`, so no retag needed).

Follow-up worth considering: add an API 26/27 emulator to `test-android.yml` — the current test matrix only exercises a recent API level, which is why this shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)