### PR TITLE
harden(prebuild): keep caller token off disk + ignore-scripts on untrusted install

### DIFF
--- a/.github/actions/prebuild/action.yml
+++ b/.github/actions/prebuild/action.yml
@@ -144,7 +144,12 @@ runs:
     - name: Install deps for package
       shell: bash
       working-directory: ./package
-      run: npm install
+      # `--ignore-scripts`: the target module is untrusted third-party
+      # code. bare-make drives the native build from CMakeLists afterwards,
+      # so no install-time lifecycle script is needed (same as the
+      # better-sqlite3 workflow). Defence-in-depth alongside the caller
+      # checkout's `persist-credentials: false`.
+      run: npm install --ignore-scripts
 
     - name: Install patched cmake-napi
       shell: bash

--- a/.github/workflows/prebuild-all.yml
+++ b/.github/workflows/prebuild-all.yml
@@ -140,8 +140,12 @@ jobs:
     name: ${{ inputs.module_name }} (${{ matrix.platform }}-${{ matrix.arch }}${{ matrix.simulator && '-simulator' || '' }})
     steps:
       # Caller's repo — needed so `patches_dir` (a caller-relative path)
-      # resolves against the workspace root.
+      # resolves against the workspace root. `persist-credentials: false`
+      # keeps the caller's GITHUB_TOKEN off disk — see the comment in
+      # prebuild.yml.
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       # Same-ref harness checkout — see the comment in prebuild.yml.
       - name: Checkout prebuild harness

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -93,8 +93,13 @@ jobs:
       module_version: ${{ steps.prebuild.outputs.module_version }}
     steps:
       # Caller's repo — needed so `patches_dir` (a caller-relative path)
-      # resolves against the workspace root.
+      # resolves against the workspace root. `persist-credentials: false`
+      # keeps the caller's GITHUB_TOKEN out of $GITHUB_WORKSPACE/.git/config
+      # so the untrusted `npm install` of the target module (with lifecycle
+      # scripts) below can't read a (release-write-capable) token off disk.
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       # Check out this repo at the SAME ref this reusable workflow is
       # running from (`job.workflow_sha` resolves the caller's @v2/@main/


### PR DESCRIPTION
Follow-up to the security review on #10. Closes the one real supply-chain exposure that review surfaced (pre-existing, not introduced by #10).

## The exposure

The prebuild jobs (`prebuild.yml`, `prebuild-all.yml`) check out the **caller repo** with `actions/checkout`'s default `persist-credentials: true`, which writes the caller's `GITHUB_TOKEN` into `$GITHUB_WORKSPACE/.git/config`. The composite action then runs `npm install` on the **untrusted third-party target module** (`sodium-native`, `better-sqlite3`, …) with lifecycle scripts enabled — so a malicious or compromised version of that module, or any transitive dep, gets arbitrary code execution in a job where that token is readable off disk.

In the sibling repos' **release** runs that token is write-capable, and those jobs publish the release artifacts that get downloaded and shipped inside the CoMapeo apps. This is the tj-actions/ultralytics pattern: untrusted build-time code reaching a privileged token.

## The fix (belt and suspenders)

- **`persist-credentials: false`** on the caller checkout in both prebuild workflows. That checkout exists only so `patches_dir` resolves against the workspace — it needs no token. No token on disk ⇒ nothing for an install script to steal.
- **`npm install --ignore-scripts`** for the target module. `bare-make` drives the native build from `CMakeLists` afterwards, so no install-time lifecycle script is required — the `better-sqlite3-nodejs-mobile` workflow already builds this exact way, so this is proven, not speculative.

## Validation

`ci.yml` runs the real prebuild → emulator-test pipeline on this PR (quickbit-native), so a green check confirms `--ignore-scripts` still produces a working, loadable `.node`.

## Out of scope

The test workflows' `assemble-test-project` also `npm install`s the module (to fetch its test runner), but those jobs carry no release-write token — lower priority, can follow separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)